### PR TITLE
Add link to Wikidata embeddings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,13 @@ This will create the `joined_embeddings.tsv` file, which is a text file where ea
 
 More information can be found in [the full documentation](https://torchbiggraph.readthedocs.io/).
 
+## Pre-trained embeddings
+
+We trained a PBG model on full [Wikidata](https://www.wikidata.org/), using [translation operator](https://torchbiggraph.readthedocs.io/en/latest/scoring.html#operators). It can be downloaded [here](https://dl.fbaipublicfiles.com/torchbiggraph/wikidata_translation_v1.tsv). The file is in tsv format as described in the above section. Note that the first line of the file contains the number of entities, number of relations and dimension of the embeddings, separated by tabs. 
+
 ## Citation
 
-To cite this work please use:
+If you use PyTorch-BigGraph or the pre-trained wikidata embeddings in your work, please cite:
 ```tex
 @inproceedings{pbg,
   title={{PyTorch-BigGraph: A Large-scale Graph Embedding System}},

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ More information can be found in [the full documentation](https://torchbiggraph.
 
 ## Pre-trained embeddings
 
-We trained a PBG model on full [Wikidata](https://www.wikidata.org/), using [translation operator](https://torchbiggraph.readthedocs.io/en/latest/scoring.html#operators). It can be downloaded [here](https://dl.fbaipublicfiles.com/torchbiggraph/wikidata_translation_v1.tsv). The file is in tsv format as described in the above section. Note that the first line of the file contains the number of entities, number of relations and dimension of the embeddings, separated by tabs. 
+We trained a PBG model on the full [Wikidata](https://www.wikidata.org/) graph, using a [translation operator](https://torchbiggraph.readthedocs.io/en/latest/scoring.html#operators) to represent relations. It can be downloaded [here](https://dl.fbaipublicfiles.com/torchbiggraph/wikidata_translation_v1.tsv). The file is in TSV format as described in the above section. Note that the first line of the file contains the number of entities, the number of relations and the dimension of the embeddings, separated by tabs. 
 
 ## Citation
 


### PR DESCRIPTION
[Copied from ledw/PyTorch-BigGraph/pull/1]

This adds a section of pre-trained wikidata embeddings in README

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
Add a new section which links to pre-trained embeddings.
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.