### PR TITLE
Use CPU-only version of PyTorch in CircleCI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,15 +36,16 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - local-python-v1-{{ .Branch }}-
-            - local-python-v1-
+            - local-python-v2-{{ .Branch }}-
+            - local-python-v2-
       - run:
           name: Set up local Python environment
           command: |
+            pip install --user torch>=1.0 --no-index --find-links https://download.pytorch.org/whl/cpu/torch_stable.html --upgrade --upgrade-strategy eager --progress-bar off
             pip install --user --requirement << parameters.requirements_file >> --upgrade --upgrade-strategy eager --progress-bar off
             pip freeze --user > << parameters.summary_file >>
       - save_cache:
-          key: local-python-v1-{{ .Branch }}-{{ checksum "<< parameters.summary_file >>" }}
+          key: local-python-v2-{{ .Branch }}-{{ checksum "<< parameters.summary_file >>" }}
           paths:
             - ~/local_python
   load_installed_dependencies:
@@ -54,13 +55,15 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - local-python-v1-{{ .Branch }}-{{ checksum "<< parameters.summary_file >>" }}
-            - local-python-v1-{{ .Branch }}-
-            - local-python-v1-
+            - local-python-v2-{{ .Branch }}-{{ checksum "<< parameters.summary_file >>" }}
+            - local-python-v2-{{ .Branch }}-
+            - local-python-v2-
+      # The cache is unreliable, so we re-install anyways: if it's full and up-to-date this will be a no-op.
       - run:
           name: Set up local Python environment
           command: |
-            pip install --user --requirement << parameters.summary_file >> --progress-bar off
+            pip install --user torch>=1.0 --no-index --find-links https://download.pytorch.org/whl/cpu/torch_stable.html --upgrade --upgrade-strategy eager --progress-bar off
+            pip install --user --requirement << parameters.summary_file >> --upgrade --upgrade-strategy eager --progress-bar off
 
 jobs:
   build-install:


### PR DESCRIPTION
It's almost 10x smaller, which means it's faster to download (both from
the upstream repository and from the cache).