### PR TITLE
Provide a gzip-compressed version of the Wikidata embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ More information can be found in [the full documentation](https://torchbiggraph.
 
 ## Pre-trained embeddings
 
-We trained a PBG model on the full [Wikidata](https://www.wikidata.org/) graph, using a [translation operator](https://torchbiggraph.readthedocs.io/en/latest/scoring.html#operators) to represent relations. It can be downloaded [here](https://dl.fbaipublicfiles.com/torchbiggraph/wikidata_translation_v1.tsv). We used the truthy version of data from [here](https://dumps.wikimedia.org/wikidatawiki/entities/) to train our model. The model file is in TSV format as described in the above section. Note that the first line of the file contains the number of entities, the number of relations and the dimension of the embeddings, separated by tabs. The model contains 78 milion entities, 4,131 relations and the dimension of the embeddings is 200.
+We trained a PBG model on the full [Wikidata](https://www.wikidata.org/) graph, using a [translation operator](https://torchbiggraph.readthedocs.io/en/latest/scoring.html#operators) to represent relations. It can be downloaded [here](https://dl.fbaipublicfiles.com/torchbiggraph/wikidata_translation_v1.tsv.gz) (36GiB, gzip-compressed). We used the truthy version of data from [here](https://dumps.wikimedia.org/wikidatawiki/entities/) to train our model. The model file is in TSV format as described in the above section. Note that the first line of the file contains the number of entities, the number of relations and the dimension of the embeddings, separated by tabs. The model contains 78 milion entities, 4,131 relations and the dimension of the embeddings is 200.
 
 ## Citation
 


### PR DESCRIPTION
112GiB are a lot to download. 36GiB are a lot too, but less.

This file was produced from the uncompressed one with `pigz -9`.
