### PR TITLE
Fix export_to_tsv exporting only the first parameter for dynamic relations

### DIFF
--- a/examples/livejournal.py
+++ b/examples/livejournal.py
@@ -35,8 +35,19 @@ def convert_path(fname):
 
 
 def random_split_file(fpath):
-    print('Shuffling and splitting train/test file. This may take a while.')
     root = os.path.dirname(fpath)
+
+    output_paths = [
+        os.path.join(root, FILENAMES['train']),
+        os.path.join(root, FILENAMES['test']),
+    ]
+    if all(os.path.exists(path) for path in output_paths):
+        print("Found some files that indicate that the input data "
+              "has already been shuffled and split, not doing it again.")
+        print("These files are: %s" % ", ".join(output_paths))
+        return
+
+    print('Shuffling and splitting train/test file. This may take a while.')
     train_file = os.path.join(root, FILENAMES['train'])
     test_file = os.path.join(root, FILENAMES['test'])
 

--- a/torchbiggraph/converters/export_to_tsv.py
+++ b/torchbiggraph/converters/export_to_tsv.py
@@ -58,16 +58,22 @@ def make_tsv(checkpoint: str, dictfile: str, outfile: str) -> None:
         # TODO Provide a better output format for relation parameters.
         print("Writing relation parameters...")
         if model.num_dynamic_rels > 0:
-            rels_lhs = next(model.lhs_operators[0].parameters())
-            for ix, rel in enumerate(relation_types):
-                write(out_tf, rel, rels_lhs[ix])
+            lhs_parameters = torch.cat([
+                parameter.view(model.num_dynamic_rels, -1)
+                for parameter in model.lhs_operators[0].parameters()
+            ], dim=1)
+            for rel_idx, rel_name in enumerate(relation_types):
+                write(out_tf, rel_name, lhs_parameters[rel_idx])
 
-            rels_rhs = next(model.rhs_operators[0].parameters())
-            for ix, rel in enumerate(relation_types):
-                write(out_tf, rel + "_reverse_relation", rels_rhs[ix])
+            rhs_parameters = torch.cat([
+                parameter.view(model.num_dynamic_rels, -1)
+                for parameter in model.rhs_operators[0].parameters()
+            ], dim=1)
+            for rel_idx, rel_name in enumerate(relation_types):
+                write(out_tf, rel_name + "_reverse_relation", rhs_parameters[rel_idx])
         else:
-            for ix, operator in enumerate(model.rhs_operators):
-                write(out_tf, model.relations[ix].name, torch.cat([
+            for rel_name, operator in zip(relation_types, model.rhs_operators):
+                write(out_tf, rel_name, torch.cat([
                     parameter.flatten() for parameter in operator.parameters()
                 ], dim=0))
 

--- a/torchbiggraph/converters/utils.py
+++ b/torchbiggraph/converters/utils.py
@@ -22,6 +22,12 @@ def extract_gzip(gzip_path: str, remove_finished: bool = False) -> str:
     if ext != ".gz":
         raise RuntimeError("Not a gzipped file")
 
+    if os.path.exists(fpath):
+        print("Found a file that indicates that the input data "
+              "has already been extracted, not doing it again.")
+        print("This file is: %s" % fpath)
+        return fpath
+
     with open(fpath, "wb") as out_bf, gzip.GzipFile(gzip_path) as zip_f:
         shutil.copyfileobj(zip_f, out_bf)
     if remove_finished:


### PR DESCRIPTION
Some operators (affine, complex_diagonal) have more than one parameters,
however export_to_tsv was only exporting the first one. This caused, for
example, the ComplEx FB15k export to have only 200 params per relation
(the real part), with the other 200 (the imaginary part) being dropped.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

See https://github.com/facebookresearch/PyTorch-BigGraph/issues/13#issuecomment-485221952

## How Has This Been Tested (if it applies)

Tested using the FB15k and (a modified version of) the LiveJournal
example scripts.