### PR TITLE
Fix parameter override not working for lists of strings in Python 3.7

### DIFF
--- a/torchbiggraph/config.py
+++ b/torchbiggraph/config.py
@@ -16,8 +16,8 @@ from typing import Any, ClassVar, Dict, List, Optional
 import attr
 from attr.validators import optional
 
-from .schema import DeepTypeError, Schema, schema, non_negative, positive, \
-    non_empty, extract_nested_type, inject_nested_value
+from .schema import has_origin, DeepTypeError, Schema, schema, non_negative, \
+    positive, non_empty, extract_nested_type, inject_nested_value
 
 
 class Operator(Enum):
@@ -408,7 +408,7 @@ def override_config_dict(config_dict: Any, overrides: List[str]) -> Any:
             # this is a bit of a hack; we should do something better
             # but this is convenient for specifying lists of strings
             # e.g. edge_paths
-            if isinstance(param_type, type) and issubclass(param_type, list):
+            if has_origin(param_type, list):
                 value = value.split(",")
             # Convert numbers (caution: ignore bools, which are ints)
             if isinstance(param_type, type) \


### PR DESCRIPTION
```
$ python3.6
>>> from typing import List
>>> isinstance(List[str], type)
True
>>> issubclass(List[str], list)
True
```
```
$ python3.7
>>> from typing import List
>>> isinstance(List[str], type)
False
>>> issubclass(List[str], list)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: issubclass() arg 1 must be a class
```

Fixes #38.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

See #38.

## How Has This Been Tested (if it applies)

Ran the `torchbiggraph_train` command reported in #38 under both Python 3.6 and 3.7.