### PR TITLE
Make it easier to invoke TSV importer/exporter from user code

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The results of [the paper](https://www.sysml.cc/doc/2019/71.pdf) can easily be r
 ```bash
 torchbiggraph_example_fb15k
 ```
-This will download the Freebase 15k knowledge base dataset, put it into the right format, train on it using the ComplEx model and finally perform an evaluation of the learned embeddings that calculates the MRR and other metrics that should match the paper. Another command, `torchbiggraph_example_livejournal`, does the same for the LiveJournal interaction graph dataset. These scripts are _not_ self-contained and are best run from a full checkout of this repository.
+This will download the Freebase 15k knowledge base dataset, put it into the right format, train on it using the ComplEx model and finally perform an evaluation of the learned embeddings that calculates the MRR and other metrics that should match the paper. Another command, `torchbiggraph_example_livejournal`, does the same for the LiveJournal interaction graph dataset.
 
 To learn how to use PBG, let us walk through what the FB15k script does.
 

--- a/torchbiggraph/converters/export_to_tsv.py
+++ b/torchbiggraph/converters/export_to_tsv.py
@@ -8,7 +8,7 @@
 
 import argparse
 import json
-from typing import Dict, Iterable, List, TextIO
+from typing import Any, Dict, IO, Iterable, List, TextIO
 
 import torch
 
@@ -20,10 +20,8 @@ def write(outf: TextIO, word: str, emb: Iterable[float]) -> None:
     outf.write("%s\t%s\n" % (word, "\t".join("%.9f" % x for x in emb)))
 
 
-def make_tsv(checkpoint: str, dictfile: str, outfile: str) -> None:
+def make_tsv(checkpoint: str, dump: Dict[str, Any], out_tf: IO[str]) -> None:
     print("Loading relation types and entities...")
-    with open(dictfile, "rt") as tf:
-        dump = json.load(tf)
     relation_types: List[str] = dump["relations"]
     entities_by_type: Dict[str, List[str]] = dump["entities"]
 
@@ -35,49 +33,48 @@ def make_tsv(checkpoint: str, dictfile: str, outfile: str) -> None:
     if state_dict is not None:
         model.load_state_dict(state_dict, strict=False)
 
-    with open(outfile, "wt") as out_tf:
-        for entity_name, entity in config.entities.items():
-            entities = entities_by_type[entity_name]
-            part_begin = 0
-            for part in range(entity.num_partitions):
-                print("Writing embeddings for entity type %s partition %d..."
-                      % (entity_name, part))
-                embs, _ = checkpoint_manager.read(entity_name, part)
+    for entity_name, entity in config.entities.items():
+        entities = entities_by_type[entity_name]
+        part_begin = 0
+        for part in range(entity.num_partitions):
+            print("Writing embeddings for entity type %s partition %d..."
+                  % (entity_name, part))
+            embs, _ = checkpoint_manager.read(entity_name, part)
 
-                if model.global_embs is not None:
-                    embs += model.global_embs[model.EMB_PREFIX + entity_name]
+            if model.global_embs is not None:
+                embs += model.global_embs[model.EMB_PREFIX + entity_name]
 
-                for ix in range(len(embs)):
-                    write(out_tf, entities[part_begin + ix], embs[ix])
-                    if (ix + 1) % 5000 == 0:
-                        print("- Processed %d entities so far..." % (ix + 1))
-                print("- Processed %d entities in total" % len(embs))
+            for ix in range(len(embs)):
+                write(out_tf, entities[part_begin + ix], embs[ix])
+                if (ix + 1) % 5000 == 0:
+                    print("- Processed %d entities so far..." % (ix + 1))
+            print("- Processed %d entities in total" % len(embs))
 
-                part_begin = part_begin + len(embs)
+            part_begin = part_begin + len(embs)
 
-        # TODO Provide a better output format for relation parameters.
-        print("Writing relation parameters...")
-        if model.num_dynamic_rels > 0:
-            lhs_parameters = torch.cat([
-                parameter.view(model.num_dynamic_rels, -1)
-                for parameter in model.lhs_operators[0].parameters()
-            ], dim=1)
-            for rel_idx, rel_name in enumerate(relation_types):
-                write(out_tf, rel_name, lhs_parameters[rel_idx])
+    # TODO Provide a better output format for relation parameters.
+    print("Writing relation parameters...")
+    if model.num_dynamic_rels > 0:
+        lhs_parameters = torch.cat([
+            parameter.view(model.num_dynamic_rels, -1)
+            for parameter in model.lhs_operators[0].parameters()
+        ], dim=1)
+        for rel_idx, rel_name in enumerate(relation_types):
+            write(out_tf, rel_name, lhs_parameters[rel_idx])
 
-            rhs_parameters = torch.cat([
-                parameter.view(model.num_dynamic_rels, -1)
-                for parameter in model.rhs_operators[0].parameters()
-            ], dim=1)
-            for rel_idx, rel_name in enumerate(relation_types):
-                write(out_tf, rel_name + "_reverse_relation", rhs_parameters[rel_idx])
-        else:
-            for rel_name, operator in zip(relation_types, model.rhs_operators):
-                write(out_tf, rel_name, torch.cat([
-                    parameter.flatten() for parameter in operator.parameters()
-                ], dim=0))
+        rhs_parameters = torch.cat([
+            parameter.view(model.num_dynamic_rels, -1)
+            for parameter in model.rhs_operators[0].parameters()
+        ], dim=1)
+        for rel_idx, rel_name in enumerate(relation_types):
+            write(out_tf, rel_name + "_reverse_relation", rhs_parameters[rel_idx])
+    else:
+        for rel_name, operator in zip(relation_types, model.rhs_operators):
+            write(out_tf, rel_name, torch.cat([
+                parameter.flatten() for parameter in operator.parameters()
+            ], dim=0))
 
-    print("Done exporting data to %s" % outfile)
+    print("Done exporting data to %s" % getattr(out_tf, "name", "the output file"))
 
 
 def main():
@@ -88,7 +85,11 @@ def main():
 
     args = parser.parse_args()
 
-    make_tsv(args.checkpoint, args.dict, args.out)
+    with open(args.dict, "rt") as tf:
+        dump = json.load(tf)
+
+    with open(args.out, "wt") as out_tf:
+        make_tsv(args.checkpoint, dump, out_tf)
 
 
 if __name__ == "__main__":

--- a/torchbiggraph/converters/import_from_tsv.py
+++ b/torchbiggraph/converters/import_from_tsv.py
@@ -247,18 +247,17 @@ def generate_edge_path_files(
 
 
 def convert_input_data(
-    config: str,
+    entity_configs: Dict[str, EntitySchema],
+    relation_configs: List[RelationSchema],
+    entity_path: str,
     edge_paths: List[str],
     lhs_col: int,
     rhs_col: int,
     rel_col: Optional[int] = None,
     entity_min_count: int = 1,
     relation_type_min_count: int = 1,
+    dynamic_relations: bool = False,
 ) -> None:
-
-    entity_configs, relation_configs, entity_path, dynamic_relations = \
-        validate_config(config)
-
     some_output_paths = []
     some_output_paths.append(os.path.join(entity_path, "dictionary.json"))
     some_output_paths.extend(
@@ -337,6 +336,8 @@ def validate_config(
     dynamic_relations = user_config.get("dynamic_relations", False)
     if not isinstance(entities_config, dict):
         raise TypeError("Config entities is not of type dict")
+    if any(not isinstance(k, str) for k in entities_config.keys()):
+        raise TypeError("Config entities has some keys that are not of type str")
     if not isinstance(relations_config, list):
         raise TypeError("Config relations is not of type list")
     if not isinstance(entity_path, str):
@@ -376,14 +377,20 @@ def main():
 
     opt = parser.parse_args()
 
+    entity_configs, relation_configs, entity_path, dynamic_relations = \
+        validate_config(opt.config)
+
     convert_input_data(
-        opt.config,
+        entity_configs,
+        relation_configs,
+        entity_path,
         opt.edge_paths,
         opt.lhs_col,
         opt.rhs_col,
         opt.rel_col,
         opt.entity_min_count,
         opt.relation_type_min_count,
+        dynamic_relations,
     )
 
 

--- a/torchbiggraph/examples/fb15k.py
+++ b/torchbiggraph/examples/fb15k.py
@@ -15,7 +15,10 @@ import pkg_resources
 
 import torchbiggraph.converters.utils as utils
 from torchbiggraph.config import parse_config
-from torchbiggraph.converters.import_from_tsv import convert_input_data
+from torchbiggraph.converters.import_from_tsv import (
+    convert_input_data,
+    validate_config,
+)
 from torchbiggraph.eval import do_eval
 from torchbiggraph.filtered_eval import FilteredRankingEvaluator
 from torchbiggraph.train import train
@@ -61,13 +64,18 @@ def main():
     utils.extract_tar(fpath)
     print('Downloaded and extracted file.')
 
+    entity_configs, relation_configs, entity_path, dynamic_relations = \
+        validate_config(args.config)
     edge_paths = [os.path.join(data_dir, name) for name in FILENAMES.values()]
     convert_input_data(
-        args.config,
+        entity_configs,
+        relation_configs,
+        entity_path,
         edge_paths,
         lhs_col=0,
         rhs_col=2,
         rel_col=1,
+        dynamic_relations=dynamic_relations,
     )
 
     config = parse_config(args.config, overrides)

--- a/torchbiggraph/examples/livejournal.py
+++ b/torchbiggraph/examples/livejournal.py
@@ -16,7 +16,10 @@ import pkg_resources
 
 import torchbiggraph.converters.utils as utils
 from torchbiggraph.config import parse_config
-from torchbiggraph.converters.import_from_tsv import convert_input_data
+from torchbiggraph.converters.import_from_tsv import (
+    convert_input_data,
+    validate_config,
+)
 from torchbiggraph.eval import do_eval
 from torchbiggraph.train import train
 
@@ -101,13 +104,18 @@ def main():
     # random split file for train and test
     random_split_file(fpath)
 
+    entity_configs, relation_configs, entity_path, dynamic_relations = \
+        validate_config(args.config)
     edge_paths = [os.path.join(data_dir, name) for name in FILENAMES.values()]
     convert_input_data(
-        args.config,
+        entity_configs,
+        relation_configs,
+        entity_path,
         edge_paths,
         lhs_col=0,
         rhs_col=1,
         rel_col=None,
+        dynamic_relations=dynamic_relations,
     )
     config = parse_config(args.config, overrides)
 

--- a/torchbiggraph/model.py
+++ b/torchbiggraph/model.py
@@ -907,9 +907,9 @@ class MultiRelationEmbedder(nn.Module):
 
         if self.num_dynamic_rels == 0:
             # In this case the operator is only applied to the RHS. This means
-            # that an edge (u, r, v) is scored with m(u, f_r(v)), whereas the
+            # that an edge (u, r, v) is scored with c(u, f_r(v)), whereas the
             # negatives (u', r, v) and (u, r, v') are scored respectively with
-            # m(u', f_r(v)) and m(u, f_r(v')). Since r is always the same, each
+            # c(u', f_r(v)) and c(u, f_r(v')). Since r is always the same, each
             # positive and negative right-hand side entity is only passed once
             # through the operator.
 
@@ -947,9 +947,9 @@ class MultiRelationEmbedder(nn.Module):
             # So, instead, we duplicate all operators, creating two versions of
             # them, one for each side, and only allow one of them to be applied
             # at any given time. The edge (u, r, v) can thus be scored in two
-            # ways, either as m(g_r(u), v) or as m(u, h_r(v)). The negatives
-            # (u', r, v) and (u, r, v') are scored respectively as m(u', h_r(v))
-            # and m(g_r(u), v'). This way we only need to perform two operator
+            # ways, either as c(g_r(u), v) or as c(u, h_r(v)). The negatives
+            # (u', r, v) and (u, r, v') are scored respectively as c(u', h_r(v))
+            # and c(g_r(u), v'). This way we only need to perform two operator
             # applications for every positive input edge, one for each side.
 
             # "Forward" edges: apply operator to rhs, sample negatives on lhs.


### PR DESCRIPTION
## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

The functions that implemented these commands required file paths as arguments, meaning one could not pass them data that was stored in memory without serializing it first.

Fixes #50.

I'm also piggybacking a fix to a comment: "m" stood for "metric", but we are now calling it "comparator", hence use "c".

## How Has This Been Tested (if it applies)

Launched both the FB15k script and the equivalent manual commands.

## Checklist

- [ ] The documentation is up-to-date with the changes I made.
- [ ] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
