### PR TITLE
Make `./setup.py test` auto-discover and run tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,16 +36,4 @@ jobs:
           name: Test all the things!
           command: |
             . ~/venv/bin/activate
-            python3 test/test_batching.py
-            python3 test/test_bucket_scheduling.py
-            python3 test/test_distributed.py
-            python3 test/test_edgelist.py
-            python3 test/test_entitylist.py
-            python3 test/test_fileio.py
-            python3 test/test_functional.py
-            python3 test/test_losses.py
-            python3 test/test_model.py
-            python3 test/test_schema.py
-            python3 test/test_stats.py
-            python3 test/test_train.py
-            python3 test/test_util.py
+            python3 setup.py test

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ keywords =
     knowledge-base
     graph-embedding
     link-prediction
+test_suite = test
 
 [options]
 setup_requires =


### PR DESCRIPTION
## Motivation and Context / Related issue

Allows users (and our continuous integration) to run all tests without having to manually list them.

## How Has This Been Tested (if it applies)

Look at the CircleCI build for this PR.