### PR TITLE
Add l2 and sql2 comparators

### DIFF
--- a/docs/source/configuration_file.rst
+++ b/docs/source/configuration_file.rst
@@ -118,7 +118,7 @@ See :ref:`scoring` for more details.
 
   If enabled, add to each embedding a vector that is common to all the entities of a certain type. This vector is learned during training.
 
-- ``comparator`` (type: string, either ``"dot"`` or ``"cos"``; default: ``"cos"``)
+- ``comparator`` (type: string, can be ``"dot"``, ``"cos"``, ``"l2"`` or ``"sql2"``; default: ``"cos"``)
 
   How the embeddings of the two sides of an edge (after having already undergone some processing) are compared to each other to produce a score.
 

--- a/docs/source/scoring.rst
+++ b/docs/source/scoring.rst
@@ -103,6 +103,8 @@ The available comparators are:
   embedding vectors;
 * ``cos``, the cos distance, which is the cosine of the angle between the two vectors
   or, equivalently, the dot product divided by the product of the vectors' norms.
+* ``l2``, the l2 norm also known as the Euclidean norm, which is the shortest distance to go from the point represented by the first vector to the point represented by the second vector.
+* ``sql2``, the squared l2 norm.
 
 Custom comparators need to extend the :class:`torchbiggraph.model.AbstractComparator` class
 and add an item to the :class:`torchbiggraph.config.Comparator` enum.

--- a/torchbiggraph/config.py
+++ b/torchbiggraph/config.py
@@ -51,6 +51,10 @@ class Comparator(Enum):
     DOT = 'dot'
     # Cosine distance.
     COS = 'cos'
+    # L2 norm.
+    L2 = 'l2'
+    # Squared L2 norm.
+    SQL2 = 'sql2'
 
 
 class LossFunction(Enum):

--- a/torchbiggraph/model.py
+++ b/torchbiggraph/model.py
@@ -556,6 +556,7 @@ class DotComparator(AbstractComparator):
 
         return pos_scores, lhs_neg_scores, rhs_neg_scores
 
+
 class CosComparator(AbstractComparator):
 
     def prepare(


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

Following the discussion in https://github.com/facebookresearch/PyTorch-BigGraph/issues/51 I open this PR to check whether there's interest in having the changes I made to implement the l2 and squared l2 comparators available for anyone.


## Implementation notes
I've experimented with 3 different implementations for the l2 comparator.
The `v1` version needs P x A x B x D memory, so it's not feasible when D is large.
The `v3` version is equivalent to the `v2` but it's more than 30 times faster.

```python
def v1_batched_cdist_l2(b1, b2):
  """b1 has size P x A x D, b2 has size b2 P x B x D, res has size P x A x B """
  res = torch.norm(b2.unsqueeze(-3) - b1.unsqueeze(-2), p=2, dim=-1)
  return res

def v2_batched_cdist_l2(b1, b2):
  """b1 has size P x A x D, b2 has size b2 P x B x D, res has size P x A x B """
  res = torch.empty(b1.size(0), b1.size(1), b2.size(1))
  for i in range(b1.size(0)):
    res[i] = torch.cdist(b1[i], b2[i], p=2.0)
  return res

def v3_batched_cdist_l2(b1, b2):
  """b1 has size P x A x D, b2 has size b2 P x B x D, res has size P x A x B """
    b1_norm = b1.pow(2).sum(dim=-1, keepdim=True)
    b2_norm = b2.pow(2).sum(dim=-1, keepdim=True)
    res = torch.baddbmm(b2_norm.transpose(-2, -1), b1, b2.transpose(-2, -1), beta=1, alpha=-2).add_(b1_norm).clamp_min_(1e-30).sqrt_()
    return res
```

<details><summary>v2 vs v3 performance test</summary>

```python
import time
import torch

@torch.jit.script
def fast_batched_cdist_l2(x1, x2):
    x1_norm = x1.pow(2).sum(dim=-1, keepdim=True)
    x2_norm = x2.pow(2).sum(dim=-1, keepdim=True)
    res = torch.baddbmm(x2_norm.transpose(-2, -1), x1, x2.transpose(-2, -1), beta=1, alpha=-2).add_(x1_norm).sqrt_()
    return res

@torch.jit.script
def slow_batched_cdist_l2(x1, x2):
  res = torch.empty(x1.size(0), x1.size(1), x2.size(1)).cuda()
  for i in range(x1.size(0)):
    res[i] = torch.cdist(x1[i], x2[i], p=2.0)
  return res

@torch.jit.script
def fast_batched_cdist_cos(x1, x2):
  return torch.bmm(x1, x2.transpose(-1, -2))

a = torch.randn(50, 1000, 400).cuda()
b = torch.randn(50, 10500, 400).cuda()

for i in range(5):
    start_time = time.time()
    res = slow_batched_cdist_l2(a, b)
    torch.cuda.synchronize()
    print(f'slow batched cdist l2 time {i}: {time.time() - start_time:.2f}s')

for i in range(5):
    start_time = time.time()
    res2 = fast_batched_cdist_l2(a, b)
    torch.cuda.synchronize()
    print(f'fast batched cdist l2 time {i}: {time.time() - start_time:.2f}s')

for i in range(5):
    start_time = time.time()
    res3 = fast_batched_cdist_cos(a, b)
    torch.cuda.synchronize()
    print(f'fast batched cdist cos time {i}: {time.time() - start_time:.2f}s')

equal = torch.all(torch.lt(torch.abs(torch.add(res, -res2)), 1e-4))
print("Equals", int(equal) == 1)
print("---\n")
```

</details>

## Performance comparison with other comparators

### Test 1 - dot build-in

| dataset | operator | comparator | dimension | num_epochs |
|---------|----------|------------|-----------|------------|
| fb15k | translation | dot | 400 | 10 |

| pos_rank | mrr | r1 | r10 | r50 | auc |
|----------|-----|----|-----|-----|-----|
| 145.077 | 0.209755 | 0.0130098 | 0.593794 | 0.812573 | 0.972499 |

<details><summary>Train log</summary>

```
Using downloaded and verified file: data/fb15k.tgz
Downloaded and extracted file.
Found some files that indicate that the input data has already been preprocessed, not doing it again.
These files are: data/FB15k/dictionary.json, data/FB15k/entity_count_all_0.txt, data/FB15k/dynamic_rel_count.txt, data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.h5, data/FB15k/freebase_mtr100_mte100-valid_partitioned/edges_0_0.h5, data/FB15k/freebase_mtr100_mte100-test_partitioned/edges_0_0.h5
2019-06-15 15:51:22  Loading entity counts...
2019-06-15 15:51:22  Creating workers...
2019-06-15 15:51:22  Initializing global model...
2019-06-15 15:51:22  Starting epoch 4 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-15 15:51:22  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-15 15:51:22  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-15 15:51:22  Loading entities
2019-06-15 15:55:55  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 273.49 s ( 0.0018 M/sec ); io: 0.03 s ( 429.40 MB/sec )
2019-06-15 15:55:55  ( 0 , 0 ): loss:  14.5916 , violators_lhs:  14.1312 , violators_rhs:  9.44573 , count:  483142
2019-06-15 15:55:55  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-15 15:55:55  Writing partitioned embeddings
2019-06-15 15:55:55  Finished epoch 4 path 1 pass 1; checkpointing global state.
2019-06-15 15:55:55  My rank: 0
2019-06-15 15:55:55  Writing metadata...
2019-06-15 15:55:56  Writing the checkpoint...
2019-06-15 15:55:56  Switching to new checkpoint version...
2019-06-15 15:55:56  Starting epoch 5 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-15 15:55:56  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-15 15:55:56  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-15 15:55:56  Loading entities
2019-06-15 15:58:49  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 173.00 s ( 0.0028 M/sec ); io: 0.06 s ( 200.64 MB/sec )
2019-06-15 15:58:49  ( 0 , 0 ): loss:  6.91881 , violators_lhs:  10.553 , violators_rhs:  6.74212 , count:  483142
2019-06-15 15:58:49  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-15 15:58:49  Writing partitioned embeddings
2019-06-15 15:58:49  Finished epoch 5 path 1 pass 1; checkpointing global state.
2019-06-15 15:58:49  My rank: 0
2019-06-15 15:58:49  Writing metadata...
2019-06-15 15:58:49  Writing the checkpoint...
2019-06-15 15:58:49  Switching to new checkpoint version...
2019-06-15 15:58:49  Starting epoch 6 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-15 15:58:49  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-15 15:58:49  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-15 15:58:49  Loading entities
2019-06-15 16:01:12  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 143.13 s ( 0.0034 M/sec ); io: 0.02 s ( 613.91 MB/sec )
2019-06-15 16:01:12  ( 0 , 0 ): loss:  5.51716 , violators_lhs:  9.74823 , violators_rhs:  6.12703 , count:  483142
2019-06-15 16:01:12  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-15 16:01:12  Writing partitioned embeddings
2019-06-15 16:01:12  Finished epoch 6 path 1 pass 1; checkpointing global state.
2019-06-15 16:01:12  My rank: 0
2019-06-15 16:01:12  Writing metadata...
2019-06-15 16:01:12  Writing the checkpoint...
2019-06-15 16:01:12  Switching to new checkpoint version...
2019-06-15 16:01:12  Starting epoch 7 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-15 16:01:12  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-15 16:01:12  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-15 16:01:12  Loading entities
2019-06-15 16:03:35  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 142.95 s ( 0.0034 M/sec ); io: 0.02 s ( 601.56 MB/sec )
2019-06-15 16:03:35  ( 0 , 0 ): loss:  4.91641 , violators_lhs:  9.38796 , violators_rhs:  5.85807 , count:  483142
2019-06-15 16:03:35  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-15 16:03:35  Writing partitioned embeddings
2019-06-15 16:03:35  Finished epoch 7 path 1 pass 1; checkpointing global state.
2019-06-15 16:03:35  My rank: 0
2019-06-15 16:03:35  Writing metadata...
2019-06-15 16:03:35  Writing the checkpoint...
2019-06-15 16:03:35  Switching to new checkpoint version...
2019-06-15 16:03:35  Starting epoch 8 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-15 16:03:35  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-15 16:03:35  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-15 16:03:35  Loading entities
2019-06-15 16:06:00  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 145.30 s ( 0.0033 M/sec ); io: 0.02 s ( 578.61 MB/sec )
2019-06-15 16:06:00  ( 0 , 0 ): loss:  4.56423 , violators_lhs:  9.17307 , violators_rhs:  5.67607 , count:  483142
2019-06-15 16:06:00  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-15 16:06:00  Writing partitioned embeddings
2019-06-15 16:06:00  Finished epoch 8 path 1 pass 1; checkpointing global state.
2019-06-15 16:06:00  My rank: 0
2019-06-15 16:06:00  Writing metadata...
2019-06-15 16:06:00  Writing the checkpoint...
2019-06-15 16:06:00  Switching to new checkpoint version...
2019-06-15 16:06:00  Starting epoch 9 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-15 16:06:00  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-15 16:06:00  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-15 16:06:00  Loading entities
2019-06-15 16:08:25  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 145.10 s ( 0.0033 M/sec ); io: 0.02 s ( 578.07 MB/sec )
2019-06-15 16:08:25  ( 0 , 0 ): loss:  4.31015 , violators_lhs:  9.04125 , violators_rhs:  5.5783 , count:  483142
2019-06-15 16:08:25  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-15 16:08:25  Writing partitioned embeddings
2019-06-15 16:08:25  Finished epoch 9 path 1 pass 1; checkpointing global state.
2019-06-15 16:08:25  My rank: 0
2019-06-15 16:08:25  Writing metadata...
2019-06-15 16:08:25  Writing the checkpoint...
2019-06-15 16:08:25  Switching to new checkpoint version...
2019-06-15 16:08:25  Starting epoch 10 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-15 16:08:25  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-15 16:08:25  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-15 16:08:25  Loading entities
2019-06-15 16:10:50  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 144.76 s ( 0.0033 M/sec ); io: 0.02 s ( 588.28 MB/sec )
2019-06-15 16:10:50  ( 0 , 0 ): loss:  4.12495 , violators_lhs:  8.90357 , violators_rhs:  5.49294 , count:  483142
2019-06-15 16:10:50  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-15 16:10:50  Writing partitioned embeddings
2019-06-15 16:10:50  Finished epoch 10 path 1 pass 1; checkpointing global state.
2019-06-15 16:10:50  My rank: 0
2019-06-15 16:10:50  Writing metadata...
2019-06-15 16:10:50  Writing the checkpoint...
2019-06-15 16:10:50  Switching to new checkpoint version...
2019-06-15 16:10:50  Exiting
2019-06-15 16:10:50  Building links map from path data/FB15k/freebase_mtr100_mte100-test_partitioned
2019-06-15 16:10:51  Done building links map from path data/FB15k/freebase_mtr100_mte100-test_partitioned
2019-06-15 16:10:51  Building links map from path data/FB15k/freebase_mtr100_mte100-valid_partitioned
2019-06-15 16:10:52  Done building links map from path data/FB15k/freebase_mtr100_mte100-valid_partitioned
2019-06-15 16:10:52  Building links map from path data/FB15k/freebase_mtr100_mte100-train_partitioned
2019-06-15 16:10:57  Done building links map from path data/FB15k/freebase_mtr100_mte100-train_partitioned
2019-06-15 16:10:57  Starting edge path 1 / 1 (data/FB15k/freebase_mtr100_mte100-test_partitioned)
2019-06-15 16:11:23  ( 0 , 0 ): Processed 59071 edges in 26 s (0.0022M/sec); load time: 0.0029 s
2019-06-15 16:11:23  Stats for edge path 1 / 1, bucket ( 0 , 0 ): pos_rank:  145.077 , mrr:  0.209755 , r1:  0.0130098 , r10:  0.593794 , r50:  0.812573 , auc:  0.972499 , count:  59071
2019-06-15 16:11:23
2019-06-15 16:11:23  Stats for edge path 1 / 1: pos_rank:  145.077 , mrr:  0.209755 , r1:  0.0130098 , r10:  0.593794 , r50:  0.812573 , auc:  0.972499 , count:  59071
2019-06-15 16:11:23
2019-06-15 16:11:23
2019-06-15 16:11:23  Stats: pos_rank:  145.077 , mrr:  0.209755 , r1:  0.0130098 , r10:  0.593794 , r50:  0.812573 , auc:  0.972499 , count:  59071
2019-06-15 16:11:23
```

</details>

### Test 2 - cos built-in

| dataset | operator | comparator | dimension | num_epochs |
|---------|----------|------------|-----------|------------|
| fb15k | translation | cos | 400 | 10 |

| pos_rank | mrr | r1 | r10 | r50 | auc |
|----------|-----|----|-----|-----|-----|
| 120.065 | 0.179064 | 0.00549339 | 0.534704 | 0.796635 | 0.984629 |

<details><summary>Train log</summary>

```
Downloading https://dl.fbaipublicfiles.com/starspace/fb15k.tgz to data/fb15k.tgz
7.67MB [00:01, 3.92MB/s]
Downloaded and extracted file.
Looking up relation types in the edge files...
- Found 1345 relation types
- Removing the ones with fewer than 1 occurrences...
- Left with 1345 relation types
- Shuffling them...
Searching for the entities in the edge files...
Entity type all:
- Found 14951 entities
- Removing the ones with fewer than 1 occurrences...
- Left with 14951 entities
- Shuffling them...
Preparing entity path data/FB15k:
- Writing count of entity type all and partition 0
- Writing count of dynamic relations
Preparing edge path data/FB15k/freebase_mtr100_mte100-train_partitioned, out of the edges found in data/FB15k/freebase_mtr100_mte100-train.txt
- Edges will be partitioned in 1 x 1 buckets.
- Processed 100000 edges so far...
- Processed 200000 edges so far...
- Processed 300000 edges so far...
- Processed 400000 edges so far...
- Processed 483142 edges in total
- Writing bucket (0, 0), containing 483142 edges...
Preparing edge path data/FB15k/freebase_mtr100_mte100-valid_partitioned, out of the edges found in data/FB15k/freebase_mtr100_mte100-valid.txt
- Edges will be partitioned in 1 x 1 buckets.
- Processed 50000 edges in total
- Writing bucket (0, 0), containing 50000 edges...
Preparing edge path data/FB15k/freebase_mtr100_mte100-test_partitioned, out of the edges found in data/FB15k/freebase_mtr100_mte100-test.txt
- Edges will be partitioned in 1 x 1 buckets.
- Processed 59071 edges in total
- Writing bucket (0, 0), containing 59071 edges...
2019-06-15 16:00:42  Loading entity counts...
2019-06-15 16:00:42  Creating workers...
2019-06-15 16:00:42  Initializing global model...
2019-06-15 16:00:42  Starting epoch 1 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-15 16:00:42  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-15 16:00:42  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-15 16:00:42  Loading entities
2019-06-15 16:05:19  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 276.91 s ( 0.0017 M/sec ); io: 0.04 s ( 272.45 MB/sec )
2019-06-15 16:05:19  ( 0 , 0 ): loss:  44.7159 , violators_lhs:  97.0741 , violators_rhs:  84.4627 , count:  483142
2019-06-15 16:05:19  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-15 16:05:19  Writing partitioned embeddings
2019-06-15 16:05:19  Finished epoch 1 path 1 pass 1; checkpointing global state.
2019-06-15 16:05:19  My rank: 0
2019-06-15 16:05:19  Writing metadata...
2019-06-15 16:05:19  Writing the checkpoint...
2019-06-15 16:05:19  Switching to new checkpoint version...
2019-06-15 16:05:19  Starting epoch 2 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-15 16:05:19  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-15 16:05:19  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-15 16:05:19  Loading entities
2019-06-15 16:10:13  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 294.04 s ( 0.0016 M/sec ); io: 0.02 s ( 563.04 MB/sec )
2019-06-15 16:10:13  ( 0 , 0 ): loss:  8.58198 , violators_lhs:  18.5955 , violators_rhs:  13.393 , count:  483142
2019-06-15 16:10:13  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-15 16:10:13  Writing partitioned embeddings
2019-06-15 16:10:13  Finished epoch 2 path 1 pass 1; checkpointing global state.
2019-06-15 16:10:13  My rank: 0
2019-06-15 16:10:13  Writing metadata...
2019-06-15 16:10:13  Writing the checkpoint...
2019-06-15 16:10:13  Switching to new checkpoint version...
2019-06-15 16:10:13  Starting epoch 3 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-15 16:10:13  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-15 16:10:13  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-15 16:10:13  Loading entities
2019-06-15 16:15:05  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 292.57 s ( 0.0017 M/sec ); io: 0.02 s ( 613.45 MB/sec )
2019-06-15 16:15:05  ( 0 , 0 ): loss:  6.30145 , violators_lhs:  13.8921 , violators_rhs:  9.48918 , count:  483142
2019-06-15 16:15:05  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-15 16:15:05  Writing partitioned embeddings
2019-06-15 16:15:05  Finished epoch 3 path 1 pass 1; checkpointing global state.
2019-06-15 16:15:05  My rank: 0
2019-06-15 16:15:05  Writing metadata...
2019-06-15 16:15:06  Writing the checkpoint...
2019-06-15 16:15:06  Switching to new checkpoint version...
2019-06-15 16:15:06  Starting epoch 4 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-15 16:15:06  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-15 16:15:06  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-15 16:15:06  Loading entities
2019-06-15 16:20:04  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 298.02 s ( 0.0016 M/sec ); io: 0.02 s ( 608.51 MB/sec )
2019-06-15 16:20:04  ( 0 , 0 ): loss:  5.26877 , violators_lhs:  11.8293 , violators_rhs:  7.87868 , count:  483142
2019-06-15 16:20:04  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-15 16:20:04  Writing partitioned embeddings
2019-06-15 16:20:04  Finished epoch 4 path 1 pass 1; checkpointing global state.
2019-06-15 16:20:04  My rank: 0
2019-06-15 16:20:04  Writing metadata...
2019-06-15 16:20:04  Writing the checkpoint...
2019-06-15 16:20:04  Switching to new checkpoint version...
2019-06-15 16:20:04  Starting epoch 5 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-15 16:20:04  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-15 16:20:04  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-15 16:20:04  Loading entities
2019-06-15 16:25:00  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 295.95 s ( 0.0016 M/sec ); io: 0.02 s ( 526.78 MB/sec )
2019-06-15 16:25:00  ( 0 , 0 ): loss:  4.67576 , violators_lhs:  10.7083 , violators_rhs:  7.03032 , count:  483142
2019-06-15 16:25:00  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-15 16:25:00  Writing partitioned embeddings
2019-06-15 16:25:00  Finished epoch 5 path 1 pass 1; checkpointing global state.
2019-06-15 16:25:00  My rank: 0
2019-06-15 16:25:00  Writing metadata...
2019-06-15 16:25:00  Writing the checkpoint...
2019-06-15 16:25:00  Switching to new checkpoint version...
2019-06-15 16:25:00  Starting epoch 6 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-15 16:25:00  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-15 16:25:00  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-15 16:25:00  Loading entities
2019-06-15 16:30:00  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 300.19 s ( 0.0016 M/sec ); io: 0.02 s ( 547.72 MB/sec )
2019-06-15 16:30:00  ( 0 , 0 ): loss:  4.28483 , violators_lhs:  10.0109 , violators_rhs:  6.51432 , count:  483142
2019-06-15 16:30:00  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-15 16:30:00  Writing partitioned embeddings
2019-06-15 16:30:00  Finished epoch 6 path 1 pass 1; checkpointing global state.
2019-06-15 16:30:00  My rank: 0
2019-06-15 16:30:00  Writing metadata...
2019-06-15 16:30:00  Writing the checkpoint...
2019-06-15 16:30:00  Switching to new checkpoint version...
2019-06-15 16:30:00  Starting epoch 7 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-15 16:30:00  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-15 16:30:00  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-15 16:30:00  Loading entities
2019-06-15 16:34:46  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 285.62 s ( 0.0017 M/sec ); io: 0.02 s ( 583.70 MB/sec )
2019-06-15 16:34:46  ( 0 , 0 ): loss:  4.01208 , violators_lhs:  9.55456 , violators_rhs:  6.16181 , count:  483142
2019-06-15 16:34:46  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-15 16:34:46  Writing partitioned embeddings
2019-06-15 16:34:46  Finished epoch 7 path 1 pass 1; checkpointing global state.
2019-06-15 16:34:46  My rank: 0
2019-06-15 16:34:46  Writing metadata...
2019-06-15 16:34:46  Writing the checkpoint...
2019-06-15 16:34:46  Switching to new checkpoint version...
2019-06-15 16:34:46  Starting epoch 8 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-15 16:34:46  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-15 16:34:46  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-15 16:34:46  Loading entities
2019-06-15 16:39:44  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 298.53 s ( 0.0016 M/sec ); io: 0.02 s ( 607.85 MB/sec )
2019-06-15 16:39:44  ( 0 , 0 ): loss:  3.81272 , violators_lhs:  9.23997 , violators_rhs:  5.92521 , count:  483142
2019-06-15 16:39:44  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-15 16:39:44  Writing partitioned embeddings
2019-06-15 16:39:44  Finished epoch 8 path 1 pass 1; checkpointing global state.
2019-06-15 16:39:44  My rank: 0
2019-06-15 16:39:44  Writing metadata...
2019-06-15 16:39:44  Writing the checkpoint...
2019-06-15 16:39:44  Switching to new checkpoint version...
2019-06-15 16:39:44  Starting epoch 9 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-15 16:39:44  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-15 16:39:44  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-15 16:39:44  Loading entities
2019-06-15 16:44:38  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 294.23 s ( 0.0016 M/sec ); io: 0.02 s ( 601.55 MB/sec )
2019-06-15 16:44:38  ( 0 , 0 ): loss:  3.65739 , violators_lhs:  9.00444 , violators_rhs:  5.7401 , count:  483142
2019-06-15 16:44:38  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-15 16:44:38  Writing partitioned embeddings
2019-06-15 16:44:38  Finished epoch 9 path 1 pass 1; checkpointing global state.
2019-06-15 16:44:38  My rank: 0
2019-06-15 16:44:38  Writing metadata...
2019-06-15 16:44:38  Writing the checkpoint...
2019-06-15 16:44:38  Switching to new checkpoint version...
2019-06-15 16:44:38  Starting epoch 10 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-15 16:44:38  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-15 16:44:38  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-15 16:44:38  Loading entities
2019-06-15 16:49:33  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 294.17 s ( 0.0016 M/sec ); io: 0.02 s ( 581.05 MB/sec )
2019-06-15 16:49:33  ( 0 , 0 ): loss:  3.5355 , violators_lhs:  8.82089 , violators_rhs:  5.60358 , count:  483142
2019-06-15 16:49:33  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-15 16:49:33  Writing partitioned embeddings
2019-06-15 16:49:33  Finished epoch 10 path 1 pass 1; checkpointing global state.
2019-06-15 16:49:33  My rank: 0
2019-06-15 16:49:33  Writing metadata...
2019-06-15 16:49:33  Writing the checkpoint...
2019-06-15 16:49:33  Switching to new checkpoint version...
2019-06-15 16:49:33  Exiting
2019-06-15 16:49:33  Building links map from path data/FB15k/freebase_mtr100_mte100-test_partitioned
2019-06-15 16:49:34  Done building links map from path data/FB15k/freebase_mtr100_mte100-test_partitioned
2019-06-15 16:49:34  Building links map from path data/FB15k/freebase_mtr100_mte100-valid_partitioned
2019-06-15 16:49:34  Done building links map from path data/FB15k/freebase_mtr100_mte100-valid_partitioned
2019-06-15 16:49:34  Building links map from path data/FB15k/freebase_mtr100_mte100-train_partitioned
2019-06-15 16:49:40  Done building links map from path data/FB15k/freebase_mtr100_mte100-train_partitioned
2019-06-15 16:49:40  Starting edge path 1 / 1 (data/FB15k/freebase_mtr100_mte100-test_partitioned)
2019-06-15 16:50:20  ( 0 , 0 ): Processed 59071 edges in 40 s (0.0015M/sec); load time: 0.0032 s
2019-06-15 16:50:20  Stats for edge path 1 / 1, bucket ( 0 , 0 ): pos_rank:  120.065 , mrr:  0.179064 , r1:  0.00549339 , r10:  0.534704 , r50:  0.796635 , auc:  0.984629 , count:  59071
2019-06-15 16:50:20
2019-06-15 16:50:20  Stats for edge path 1 / 1: pos_rank:  120.065 , mrr:  0.179064 , r1:  0.00549339 , r10:  0.534704 , r50:  0.796635 , auc:  0.984629 , count:  59071
2019-06-15 16:50:20
2019-06-15 16:50:20
2019-06-15 16:50:20  Stats: pos_rank:  120.065 , mrr:  0.179064 , r1:  0.00549339 , r10:  0.534704 , r50:  0.796635 , auc:  0.984629 , count:  59071
2019-06-15 16:50:20
```

</details>

### Test 3 - l2
| dataset | operator | comparator | dimension | num_epochs |
|---------|----------|------------|-----------|------------|
| fb15k | translation | l2 | 400 | 10 |

| pos_rank | mrr | r1 | r10 | r50 | auc |
|----------|-----|----|-----|-----|-----|
| 110.637 | 0.212142 | 0.00724552 | 0.578727 | 0.794375 | 0.814731 |

<details><summary>Train log</summary>

```
Downloading https://dl.fbaipublicfiles.com/starspace/fb15k.tgz to data/fb15k.tgz
7.67MB [00:02, 3.06MB/s]
Downloaded and extracted file.
Looking up relation types in the edge files...
- Found 1345 relation types
- Removing the ones with fewer than 1 occurrences...
- Left with 1345 relation types
- Shuffling them...
Searching for the entities in the edge files...
Entity type all:
- Found 14951 entities
- Removing the ones with fewer than 1 occurrences...
- Left with 14951 entities
- Shuffling them...
Preparing entity path data/FB15k:
- Writing count of entity type all and partition 0
- Writing count of dynamic relations
Preparing edge path data/FB15k/freebase_mtr100_mte100-train_partitioned, out of the edges found in data/FB15k/freebase_mtr100_mte100-train.txt
- Edges will be partitioned in 1 x 1 buckets.
- Processed 100000 edges so far...
- Processed 200000 edges so far...
- Processed 300000 edges so far...
- Processed 400000 edges so far...
- Processed 483142 edges in total
- Writing bucket (0, 0), containing 483142 edges...
Preparing edge path data/FB15k/freebase_mtr100_mte100-valid_partitioned, out of the edges found in data/FB15k/freebase_mtr100_mte100-valid.txt
- Edges will be partitioned in 1 x 1 buckets.
- Processed 50000 edges in total
- Writing bucket (0, 0), containing 50000 edges...
Preparing edge path data/FB15k/freebase_mtr100_mte100-test_partitioned, out of the edges found in data/FB15k/freebase_mtr100_mte100-test.txt
- Edges will be partitioned in 1 x 1 buckets.
- Processed 59071 edges in total
- Writing bucket (0, 0), containing 59071 edges...
2019-06-16 08:00:33  Loading entity counts...
2019-06-16 08:00:33  Creating workers...
2019-06-16 08:00:33  Initializing global model...
2019-06-16 08:00:33  Starting epoch 1 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-16 08:00:33  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-16 08:00:33  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-16 08:00:33  Loading entities
2019-06-16 08:04:39  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 245.68 s ( 0.002 M/sec ); io: 0.04 s ( 267.86 MB/sec )
2019-06-16 08:04:39  ( 0 , 0 ): loss:  88.4376 , violators_lhs:  78.1524 , violators_rhs:  64.1903 , count:  483142
2019-06-16 08:04:39  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-16 08:04:39  Writing partitioned embeddings
2019-06-16 08:04:39  Finished epoch 1 path 1 pass 1; checkpointing global state.
2019-06-16 08:04:39  My rank: 0
2019-06-16 08:04:39  Writing metadata...
2019-06-16 08:04:39  Writing the checkpoint...
2019-06-16 08:04:39  Switching to new checkpoint version...
2019-06-16 08:04:39  Starting epoch 2 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-16 08:04:39  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-16 08:04:39  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-16 08:04:39  Loading entities
2019-06-16 08:08:40  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 240.91 s ( 0.002 M/sec ); io: 0.02 s ( 608.09 MB/sec )
2019-06-16 08:08:40  ( 0 , 0 ): loss:  9.243 , violators_lhs:  16.7189 , violators_rhs:  11.699 , count:  483142
2019-06-16 08:08:40  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-16 08:08:40  Writing partitioned embeddings
2019-06-16 08:08:40  Finished epoch 2 path 1 pass 1; checkpointing global state.
2019-06-16 08:08:40  My rank: 0
2019-06-16 08:08:40  Writing metadata...
2019-06-16 08:08:40  Writing the checkpoint...
2019-06-16 08:08:40  Switching to new checkpoint version...
2019-06-16 08:08:40  Starting epoch 3 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-16 08:08:40  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-16 08:08:40  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-16 08:08:40  Loading entities
2019-06-16 08:12:38  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 238.65 s ( 0.002 M/sec ); io: 0.02 s ( 621.39 MB/sec )
2019-06-16 08:12:38  ( 0 , 0 ): loss:  6.64181 , violators_lhs:  13.0709 , violators_rhs:  8.69191 , count:  483142
2019-06-16 08:12:38  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-16 08:12:38  Writing partitioned embeddings
2019-06-16 08:12:38  Finished epoch 3 path 1 pass 1; checkpointing global state.
2019-06-16 08:12:38  My rank: 0
2019-06-16 08:12:38  Writing metadata...
2019-06-16 08:12:38  Writing the checkpoint...
2019-06-16 08:12:38  Switching to new checkpoint version...
2019-06-16 08:12:38  Starting epoch 4 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-16 08:12:38  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-16 08:12:38  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-16 08:12:38  Loading entities
2019-06-16 08:16:38  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 239.26 s ( 0.002 M/sec ); io: 0.02 s ( 608.98 MB/sec )
2019-06-16 08:16:38  ( 0 , 0 ): loss:  5.54643 , violators_lhs:  11.4315 , violators_rhs:  7.39935 , count:  483142
2019-06-16 08:16:38  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-16 08:16:38  Writing partitioned embeddings
2019-06-16 08:16:38  Finished epoch 4 path 1 pass 1; checkpointing global state.
2019-06-16 08:16:38  My rank: 0
2019-06-16 08:16:38  Writing metadata...
2019-06-16 08:16:38  Writing the checkpoint...
2019-06-16 08:16:38  Switching to new checkpoint version...
2019-06-16 08:16:38  Starting epoch 5 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-16 08:16:38  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-16 08:16:38  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-16 08:16:38  Loading entities
2019-06-16 08:20:39  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 241.40 s ( 0.002 M/sec ); io: 0.02 s ( 594.53 MB/sec )
2019-06-16 08:20:39  ( 0 , 0 ): loss:  4.95662 , violators_lhs:  10.5781 , violators_rhs:  6.72665 , count:  483142
2019-06-16 08:20:39  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-16 08:20:39  Writing partitioned embeddings
2019-06-16 08:20:39  Finished epoch 5 path 1 pass 1; checkpointing global state.
2019-06-16 08:20:39  My rank: 0
2019-06-16 08:20:39  Writing metadata...
2019-06-16 08:20:39  Writing the checkpoint...
2019-06-16 08:20:39  Switching to new checkpoint version...
2019-06-16 08:20:39  Starting epoch 6 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-16 08:20:39  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-16 08:20:39  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-16 08:20:39  Loading entities
2019-06-16 08:24:45  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 245.65 s ( 0.002 M/sec ); io: 0.02 s ( 606.74 MB/sec )
2019-06-16 08:24:45  ( 0 , 0 ): loss:  4.60086 , violators_lhs:  10.0657 , violators_rhs:  6.36515 , count:  483142
2019-06-16 08:24:45  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-16 08:24:45  Writing partitioned embeddings
2019-06-16 08:24:45  Finished epoch 6 path 1 pass 1; checkpointing global state.
2019-06-16 08:24:45  My rank: 0
2019-06-16 08:24:45  Writing metadata...
2019-06-16 08:24:45  Writing the checkpoint...
2019-06-16 08:24:45  Switching to new checkpoint version...
2019-06-16 08:24:45  Starting epoch 7 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-16 08:24:45  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-16 08:24:45  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-16 08:24:45  Loading entities
2019-06-16 08:28:49  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 243.64 s ( 0.002 M/sec ); io: 0.02 s ( 615.71 MB/sec )
2019-06-16 08:28:49  ( 0 , 0 ): loss:  4.35041 , violators_lhs:  9.75259 , violators_rhs:  6.09646 , count:  483142
2019-06-16 08:28:49  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-16 08:28:49  Writing partitioned embeddings
2019-06-16 08:28:49  Finished epoch 7 path 1 pass 1; checkpointing global state.
2019-06-16 08:28:49  My rank: 0
2019-06-16 08:28:49  Writing metadata...
2019-06-16 08:28:49  Writing the checkpoint...
2019-06-16 08:28:49  Switching to new checkpoint version...
2019-06-16 08:28:49  Starting epoch 8 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-16 08:28:49  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-16 08:28:49  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-16 08:28:49  Loading entities
2019-06-16 08:32:49  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 240.52 s ( 0.002 M/sec ); io: 0.02 s ( 530.29 MB/sec )
2019-06-16 08:32:49  ( 0 , 0 ): loss:  4.18175 , violators_lhs:  9.54577 , violators_rhs:  5.9242 , count:  483142
2019-06-16 08:32:49  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-16 08:32:49  Writing partitioned embeddings
2019-06-16 08:32:49  Finished epoch 8 path 1 pass 1; checkpointing global state.
2019-06-16 08:32:49  My rank: 0
2019-06-16 08:32:49  Writing metadata...
2019-06-16 08:32:49  Writing the checkpoint...
2019-06-16 08:32:49  Switching to new checkpoint version...
2019-06-16 08:32:49  Starting epoch 9 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-16 08:32:49  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-16 08:32:49  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-16 08:32:49  Loading entities
2019-06-16 08:36:51  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 241.42 s ( 0.002 M/sec ); io: 0.02 s ( 574.00 MB/sec )
2019-06-16 08:36:51  ( 0 , 0 ): loss:  4.04326 , violators_lhs:  9.37396 , violators_rhs:  5.80082 , count:  483142
2019-06-16 08:36:51  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-16 08:36:51  Writing partitioned embeddings
2019-06-16 08:36:51  Finished epoch 9 path 1 pass 1; checkpointing global state.
2019-06-16 08:36:51  My rank: 0
2019-06-16 08:36:51  Writing metadata...
2019-06-16 08:36:51  Writing the checkpoint...
2019-06-16 08:36:51  Switching to new checkpoint version...
2019-06-16 08:36:51  Starting epoch 10 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-16 08:36:51  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-16 08:36:51  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-16 08:36:51  Loading entities
2019-06-16 08:40:50  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 239.48 s ( 0.002 M/sec ); io: 0.02 s ( 602.18 MB/sec )
2019-06-16 08:40:50  ( 0 , 0 ): loss:  3.93287 , violators_lhs:  9.23464 , violators_rhs:  5.71071 , count:  483142
2019-06-16 08:40:50  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-16 08:40:50  Writing partitioned embeddings
2019-06-16 08:40:50  Finished epoch 10 path 1 pass 1; checkpointing global state.
2019-06-16 08:40:50  My rank: 0
2019-06-16 08:40:50  Writing metadata...
2019-06-16 08:40:50  Writing the checkpoint...
2019-06-16 08:40:50  Switching to new checkpoint version...
2019-06-16 08:40:50  Exiting
2019-06-16 08:40:50  Building links map from path data/FB15k/freebase_mtr100_mte100-test_partitioned
2019-06-16 08:40:51  Done building links map from path data/FB15k/freebase_mtr100_mte100-test_partitioned
2019-06-16 08:40:51  Building links map from path data/FB15k/freebase_mtr100_mte100-valid_partitioned
2019-06-16 08:40:52  Done building links map from path data/FB15k/freebase_mtr100_mte100-valid_partitioned
2019-06-16 08:40:52  Building links map from path data/FB15k/freebase_mtr100_mte100-train_partitioned
2019-06-16 08:40:57  Done building links map from path data/FB15k/freebase_mtr100_mte100-train_partitioned
2019-06-16 08:40:57  Starting edge path 1 / 1 (data/FB15k/freebase_mtr100_mte100-test_partitioned)
2019-06-16 08:41:33  ( 0 , 0 ): Processed 59071 edges in 36 s (0.0016M/sec); load time: 0.0032 s
2019-06-16 08:41:33  Stats for edge path 1 / 1, bucket ( 0 , 0 ): pos_rank:  110.637 , mrr:  0.212142 , r1:  0.00724552 , r10:  0.578727 , r50:  0.794375 , auc:  0.814731 , count:  59071
2019-06-16 08:41:33
2019-06-16 08:41:33  Stats for edge path 1 / 1: pos_rank:  110.637 , mrr:  0.212142 , r1:  0.00724552 , r10:  0.578727 , r50:  0.794375 , auc:  0.814731 , count:  59071
2019-06-16 08:41:33
2019-06-16 08:41:33
2019-06-16 08:41:33  Stats: pos_rank:  110.637 , mrr:  0.212142 , r1:  0.00724552 , r10:  0.578727 , r50:  0.794375 , auc:  0.814731 , count:  59071
2019-06-16 08:41:33
```

</details>

### Test 4 - squared l2
| dataset | operator | comparator | dimension | num_epochs |
|---------|----------|------------|-----------|------------|
| fb15k | translation | sql2 | 400 | 10 |

| pos_rank | mrr | r1 | r10 | r50 | auc |
|----------|-----|----|-----|-----|-----|
| 194.273 | 0.153504 | 0.0122988 | 0.435992 | 0.689315 | 0.881194 |

<details><summary>Train log</summary>

```
Downloading https://dl.fbaipublicfiles.com/starspace/fb15k.tgz to data/fb15k.tgz
7.67MB [00:01, 7.47MB/s]
Downloaded and extracted file.
Looking up relation types in the edge files...
- Found 1345 relation types
- Removing the ones with fewer than 1 occurrences...
- Left with 1345 relation types
- Shuffling them...
Searching for the entities in the edge files...
Entity type all:
- Found 14951 entities
- Removing the ones with fewer than 1 occurrences...
- Left with 14951 entities
- Shuffling them...
Preparing entity path data/FB15k:
- Writing count of entity type all and partition 0
- Writing count of dynamic relations
Preparing edge path data/FB15k/freebase_mtr100_mte100-train_partitioned, out of the edges found in data/FB15k/freebase_mtr100_mte100-train.txt
- Edges will be partitioned in 1 x 1 buckets.
- Processed 100000 edges so far...
- Processed 200000 edges so far...
- Processed 300000 edges so far...
- Processed 400000 edges so far...
- Processed 483142 edges in total
- Writing bucket (0, 0), containing 483142 edges...
Preparing edge path data/FB15k/freebase_mtr100_mte100-valid_partitioned, out of the edges found in data/FB15k/freebase_mtr100_mte100-valid.txt
- Edges will be partitioned in 1 x 1 buckets.
- Processed 50000 edges in total
- Writing bucket (0, 0), containing 50000 edges...
Preparing edge path data/FB15k/freebase_mtr100_mte100-test_partitioned, out of the edges found in data/FB15k/freebase_mtr100_mte100-test.txt
- Edges will be partitioned in 1 x 1 buckets.
- Processed 59071 edges in total
- Writing bucket (0, 0), containing 59071 edges...
2019-06-16 08:03:32  Loading entity counts...
2019-06-16 08:03:32  Creating workers...
2019-06-16 08:03:32  Initializing global model...
2019-06-16 08:03:32  Starting epoch 1 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-16 08:03:32  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-16 08:03:32  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-16 08:03:32  Loading entities
2019-06-16 08:06:40  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 187.68 s ( 0.0026 M/sec ); io: 0.04 s ( 281.26 MB/sec )
2019-06-16 08:06:40  ( 0 , 0 ): loss:  7661.85 , violators_lhs:  119.276 , violators_rhs:  98.9583 , count:  483142
2019-06-16 08:06:40  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-16 08:06:40  Writing partitioned embeddings
2019-06-16 08:06:40  Finished epoch 1 path 1 pass 1; checkpointing global state.
2019-06-16 08:06:40  My rank: 0
2019-06-16 08:06:40  Writing metadata...
2019-06-16 08:06:40  Writing the checkpoint...
2019-06-16 08:06:40  Switching to new checkpoint version...
2019-06-16 08:06:40  Starting epoch 2 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-16 08:06:40  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-16 08:06:40  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-16 08:06:40  Loading entities
2019-06-16 08:09:53  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 193.56 s ( 0.0025 M/sec ); io: 0.02 s ( 608.94 MB/sec )
2019-06-16 08:09:53  ( 0 , 0 ): loss:  507.041 , violators_lhs:  23.5631 , violators_rhs:  17.5314 , count:  483142
2019-06-16 08:09:53  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-16 08:09:53  Writing partitioned embeddings
2019-06-16 08:09:53  Finished epoch 2 path 1 pass 1; checkpointing global state.
2019-06-16 08:09:53  My rank: 0
2019-06-16 08:09:53  Writing metadata...
2019-06-16 08:09:53  Writing the checkpoint...
2019-06-16 08:09:53  Switching to new checkpoint version...
2019-06-16 08:09:53  Starting epoch 3 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-16 08:09:53  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-16 08:09:53  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-16 08:09:53  Loading entities
2019-06-16 08:13:06  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 193.06 s ( 0.0025 M/sec ); io: 0.02 s ( 620.17 MB/sec )
2019-06-16 08:13:06  ( 0 , 0 ): loss:  254.373 , violators_lhs:  17.2481 , violators_rhs:  12.2218 , count:  483142
2019-06-16 08:13:06  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-16 08:13:06  Writing partitioned embeddings
2019-06-16 08:13:06  Finished epoch 3 path 1 pass 1; checkpointing global state.
2019-06-16 08:13:06  My rank: 0
2019-06-16 08:13:06  Writing metadata...
2019-06-16 08:13:06  Writing the checkpoint...
2019-06-16 08:13:06  Switching to new checkpoint version...
2019-06-16 08:13:06  Starting epoch 4 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-16 08:13:06  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-16 08:13:06  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-16 08:13:06  Loading entities
2019-06-16 08:16:10  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 183.89 s ( 0.0026 M/sec ); io: 0.02 s ( 633.62 MB/sec )
2019-06-16 08:16:10  ( 0 , 0 ): loss:  182.004 , violators_lhs:  14.7293 , violators_rhs:  10.1706 , count:  483142
2019-06-16 08:16:10  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-16 08:16:10  Writing partitioned embeddings
2019-06-16 08:16:10  Finished epoch 4 path 1 pass 1; checkpointing global state.
2019-06-16 08:16:10  My rank: 0
2019-06-16 08:16:10  Writing metadata...
2019-06-16 08:16:10  Writing the checkpoint...
2019-06-16 08:16:10  Switching to new checkpoint version...
2019-06-16 08:16:10  Starting epoch 5 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-16 08:16:10  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-16 08:16:10  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-16 08:16:10  Loading entities
2019-06-16 08:19:18  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 187.56 s ( 0.0026 M/sec ); io: 0.02 s ( 624.95 MB/sec )
2019-06-16 08:19:18  ( 0 , 0 ): loss:  148.226 , violators_lhs:  13.3409 , violators_rhs:  9.07335 , count:  483142
2019-06-16 08:19:18  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-16 08:19:18  Writing partitioned embeddings
2019-06-16 08:19:18  Finished epoch 5 path 1 pass 1; checkpointing global state.
2019-06-16 08:19:18  My rank: 0
2019-06-16 08:19:18  Writing metadata...
2019-06-16 08:19:18  Writing the checkpoint...
2019-06-16 08:19:18  Switching to new checkpoint version...
2019-06-16 08:19:18  Starting epoch 6 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-16 08:19:18  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-16 08:19:18  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-16 08:19:18  Loading entities
2019-06-16 08:22:25  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 186.85 s ( 0.0026 M/sec ); io: 0.02 s ( 618.41 MB/sec )
2019-06-16 08:22:25  ( 0 , 0 ): loss:  128.141 , violators_lhs:  12.4415 , violators_rhs:  8.37306 , count:  483142
2019-06-16 08:22:25  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-16 08:22:25  Writing partitioned embeddings
2019-06-16 08:22:25  Finished epoch 6 path 1 pass 1; checkpointing global state.
2019-06-16 08:22:25  My rank: 0
2019-06-16 08:22:25  Writing metadata...
2019-06-16 08:22:25  Writing the checkpoint...
2019-06-16 08:22:25  Switching to new checkpoint version...
2019-06-16 08:22:25  Starting epoch 7 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-16 08:22:25  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-16 08:22:25  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-16 08:22:25  Loading entities
2019-06-16 08:25:31  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 186.44 s ( 0.0026 M/sec ); io: 0.02 s ( 622.87 MB/sec )
2019-06-16 08:25:31  ( 0 , 0 ): loss:  114.791 , violators_lhs:  11.821 , violators_rhs:  7.91202 , count:  483142
2019-06-16 08:25:31  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-16 08:25:31  Writing partitioned embeddings
2019-06-16 08:25:31  Finished epoch 7 path 1 pass 1; checkpointing global state.
2019-06-16 08:25:31  My rank: 0
2019-06-16 08:25:31  Writing metadata...
2019-06-16 08:25:31  Writing the checkpoint...
2019-06-16 08:25:31  Switching to new checkpoint version...
2019-06-16 08:25:31  Starting epoch 8 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-16 08:25:31  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-16 08:25:31  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-16 08:25:31  Loading entities
2019-06-16 08:28:41  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 189.67 s ( 0.0025 M/sec ); io: 0.02 s ( 651.04 MB/sec )
2019-06-16 08:28:41  ( 0 , 0 ): loss:  104.543 , violators_lhs:  11.3832 , violators_rhs:  7.55052 , count:  483142
2019-06-16 08:28:41  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-16 08:28:41  Writing partitioned embeddings
2019-06-16 08:28:41  Finished epoch 8 path 1 pass 1; checkpointing global state.
2019-06-16 08:28:41  My rank: 0
2019-06-16 08:28:41  Writing metadata...
2019-06-16 08:28:41  Writing the checkpoint...
2019-06-16 08:28:41  Switching to new checkpoint version...
2019-06-16 08:28:41  Starting epoch 9 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-16 08:28:41  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-16 08:28:41  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-16 08:28:41  Loading entities
2019-06-16 08:31:51  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 189.59 s ( 0.0025 M/sec ); io: 0.02 s ( 631.41 MB/sec )
2019-06-16 08:31:51  ( 0 , 0 ): loss:  96.742 , violators_lhs:  11.0435 , violators_rhs:  7.25586 , count:  483142
2019-06-16 08:31:51  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-16 08:31:51  Writing partitioned embeddings
2019-06-16 08:31:51  Finished epoch 9 path 1 pass 1; checkpointing global state.
2019-06-16 08:31:51  My rank: 0
2019-06-16 08:31:51  Writing metadata...
2019-06-16 08:31:51  Writing the checkpoint...
2019-06-16 08:31:51  Switching to new checkpoint version...
2019-06-16 08:31:51  Starting epoch 10 / 10 edge path 1 / 1 edge chunk 1 / 1
2019-06-16 08:31:51  edge_path= data/FB15k/freebase_mtr100_mte100-train_partitioned
still in queue: 0
2019-06-16 08:31:51  Swapping partitioned embeddings None ( 0 , 0 )
2019-06-16 08:31:51  Loading entities
2019-06-16 08:35:00  ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 189.62 s ( 0.0025 M/sec ); io: 0.02 s ( 619.05 MB/sec )
2019-06-16 08:35:00  ( 0 , 0 ): loss:  90.509 , violators_lhs:  10.7862 , violators_rhs:  7.05978 , count:  483142
2019-06-16 08:35:00  Swapping partitioned embeddings ( 0 , 0 ) None
2019-06-16 08:35:00  Writing partitioned embeddings
2019-06-16 08:35:00  Finished epoch 10 path 1 pass 1; checkpointing global state.
2019-06-16 08:35:00  My rank: 0
2019-06-16 08:35:00  Writing metadata...
2019-06-16 08:35:00  Writing the checkpoint...
2019-06-16 08:35:00  Switching to new checkpoint version...
2019-06-16 08:35:01  Exiting
2019-06-16 08:35:01  Building links map from path data/FB15k/freebase_mtr100_mte100-test_partitioned
2019-06-16 08:35:01  Done building links map from path data/FB15k/freebase_mtr100_mte100-test_partitioned
2019-06-16 08:35:01  Building links map from path data/FB15k/freebase_mtr100_mte100-valid_partitioned
2019-06-16 08:35:02  Done building links map from path data/FB15k/freebase_mtr100_mte100-valid_partitioned
2019-06-16 08:35:02  Building links map from path data/FB15k/freebase_mtr100_mte100-train_partitioned
2019-06-16 08:35:07  Done building links map from path data/FB15k/freebase_mtr100_mte100-train_partitioned
2019-06-16 08:35:07  Starting edge path 1 / 1 (data/FB15k/freebase_mtr100_mte100-test_partitioned)
2019-06-16 08:35:36  ( 0 , 0 ): Processed 59071 edges in 29 s (0.002M/sec); load time: 0.003 s
2019-06-16 08:35:36  Stats for edge path 1 / 1, bucket ( 0 , 0 ): pos_rank:  194.273 , mrr:  0.153504 , r1:  0.0122988 , r10:  0.435992 , r50:  0.689315 , auc:  0.881194 , count:  59071
2019-06-16 08:35:36
2019-06-16 08:35:36  Stats for edge path 1 / 1: pos_rank:  194.273 , mrr:  0.153504 , r1:  0.0122988 , r10:  0.435992 , r50:  0.689315 , auc:  0.881194 , count:  59071
2019-06-16 08:35:36
2019-06-16 08:35:36
2019-06-16 08:35:36  Stats: pos_rank:  194.273 , mrr:  0.153504 , r1:  0.0122988 , r10:  0.435992 , r50:  0.689315 , auc:  0.881194 , count:  59071
2019-06-16 08:35:36
```

</details>

### Test script

<details><summary>Show code</summary>

```python
#! pip install torchbiggraph -qq
! rm -rf PyTorch-BigGraph
! git clone -q --branch new-comparators https://github.com/simonepri/PyTorch-BigGraph
! cd PyTorch-BigGraph && pip install . -qq

fb15k_config = """
#!/usr/bin/env python3

# Copyright (c) Facebook, Inc. and its affiliates.
# All rights reserved.
#
# This source code is licensed under the BSD-style license found in the
# LICENSE.txt file in the root directory of this source tree.

entity_base = 'data/FB15k'


def get_torchbiggraph_config():

    config = dict(
        # I/O data
        entity_path=entity_base,
        edge_paths=[],
        checkpoint_path='model/fb15k',

        # Graph structure
        entities={
            'all': {'num_partitions': 1},
        },
        relations=[{
            'name': 'all_edges',
            'lhs': 'all',
            'rhs': 'all',
            'operator': 'translation',
        }],
        dynamic_relations=True,

        # Scoring model
        dimension=400,
        global_emb=False,
        comparator='l2',

        # Training
        num_epochs=10,
        num_uniform_negs=1000,
        loss_fn='ranking',
        lr=0.1,

        # Evaluation during training
        eval_fraction=0,  # to reproduce results, we need to use all training data
    )

    return config

"""

! echo "$fb15k_config" > fb15k_config.py
! python3 PyTorch-BigGraph/torchbiggraph/examples/fb15k.py --config fb15k_config.py
```

</details>

## How Has This Been Tested (if it applies)

Tests for the new comparators still need to be written.

## Checklist

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
