### PR TITLE
Fix nan loss for cos comparator

### DIFF
--- a/torchbiggraph/model.py
+++ b/torchbiggraph/model.py
@@ -567,7 +567,7 @@ class CosComparator(AbstractComparator):
         # reciprocal of the norm costs N divisions and N * dim multiplications.
         # The latter one is faster.
         norm = embs.norm(2, dim=-1)
-        return embs * norm.reciprocal().unsqueeze(-1)
+        return embs * norm.clamp_min(1e-30).reciprocal_().unsqueeze(-1)
 
     def forward(
         self,


### PR DESCRIPTION
## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

Closes https://github.com/facebookresearch/PyTorch-BigGraph/issues/53.

## How Has This Been Tested (if it applies)

More tests needs to be added to test the behaviour of the cos comparator when a vector of all zeros is provided to avoid regressions in the future. See https://github.com/facebookresearch/PyTorch-BigGraph/issues/53#issuecomment-502443027.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
