### PR TITLE
Fix prepare_negatives function

### DIFF
--- a/torchbiggraph/model.py
+++ b/torchbiggraph/model.py
@@ -804,8 +804,12 @@ class MultiRelationEmbedder(nn.Module):
         if type_ is Negatives.NONE:
             neg_embs = torch.empty((num_chunks, 0, dim))
         elif type_ is Negatives.UNIFORM:
-            neg_embs = module.sample_entities(
+            uniform_neg_embs = module.sample_entities(
                 num_chunks, num_uniform_neg)
+            neg_embs = self.adjust_embs(
+                uniform_neg_embs,
+                rel, entity_type, operator,
+            )
         elif type_ is Negatives.BATCH_UNIFORM:
             neg_embs = pos_embs
             if num_uniform_neg > 0:


### PR DESCRIPTION
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

In https://github.com/facebookresearch/PyTorch-BigGraph/issues/52#issuecomment-502459136 I noted that when the sampling strategy is `Negatives.UNIFORM` the  negatives sampled by `prepare_negatives` are not passed through the `adjust_embs` function, and thus the comparator's prepare function is not applied on them.

I'm not sure whether this is intended (if so why?) or is a bug.

## How Has This Been Tested (if it applies)

```python3
# dataset
  link: 'https://github.com/simonepri/datasets-knowledge-embedding/releases/latest/download/WN18.tgz'

# config
  operator: 'translation', max_norm: 1.0, comparator: 'cos', loss_fn = 'ranking',
  num_epochs: 50, batch_size: 1000, num_batch_negs = 0, num_uniform_negs: 100

# stats with fix (3-runs):
  pos_rank:  893.009 , mrr:  0.111437 , r1:  0.0048 , r10:  0.3423 , r50:  0.5834 , auc:  0.9715
  pos_rank:  986.098 , mrr:  0.113513 , r1:  0.0092 , r10:  0.3439 , r50:  0.5808 , auc:  0.9650
  pos_rank:  954.332 , mrr:  0.119977 , r1:  0.0109 , r10:  0.3545 , r50:  0.6001 , auc:  0.9625

# stats without fix (3-runs):
  pos_rank:  1399.98 , mrr:  0.121685 , r1:  0.0129 , r10:  0.3543 , r50:  0.5442 , auc:  0.9458
  pos_rank:  1558.65 , mrr:  0.124991 , r1:  0.0171 , r10:  0.3528 , r50:  0.5299 , auc:  0.9404
  pos_rank:  1554.07 , mrr:  0.120086 , r1:  0.0153 , r10:  0.3378 , r50:  0.5144 , auc:  0.9399
```

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
