### PR TITLE
Allow the use of separate output stream for entities and relations in make_tsv

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ During preprocessing, the entities and relation types had their identifiers conv
 torchbiggraph_export_to_tsv \
   --dict data/FB15k/dictionary.json \
   --checkpoint model/fb15k \
-  --out joined_embeddings.tsv
+  --out-ent joined_embeddings.tsv
+  --out-rel joined_embeddings.tsv
 ```
 This will create the `joined_embeddings.tsv` file, which is a text file where each line contains the identifier of an entity or the name of a relation type followed respectively by its embedding or its parameters, each in a different column, all separated by tabs. For example, with each line shortened for brevity:
 ```

--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ During preprocessing, the entities and relation types had their identifiers conv
 torchbiggraph_export_to_tsv \
   --dict data/FB15k/dictionary.json \
   --checkpoint model/fb15k \
-  --out-ent joined_embeddings.tsv
-  --out-rel joined_embeddings.tsv
+  --entities-output joined_embeddings.tsv
+  --relation-types-output joined_embeddings.tsv
 ```
 This will create the `joined_embeddings.tsv` file, which is a text file where each line contains the identifier of an entity or the name of a relation type followed respectively by its embedding or its parameters, each in a different column, all separated by tabs. For example, with each line shortened for brevity:
 ```

--- a/torchbiggraph/converters/export_to_tsv.py
+++ b/torchbiggraph/converters/export_to_tsv.py
@@ -24,8 +24,8 @@ def make_tsv(
     checkpoint: str,
     relation_types: List[str],
     entities_by_type: Dict[str, List[str]],
-    ent_out_file: IO[str],
-    rel_out_file: IO[str],
+    entities_output_file: IO[str],
+    relation_types_output_file: IO[str],
 ) -> None:
     print("Loading model check point...")
     checkpoint_manager = CheckpointManager(checkpoint)
@@ -47,14 +47,15 @@ def make_tsv(
                 embs += model.global_embs[model.EMB_PREFIX + entity_name]
 
             for ix in range(len(embs)):
-                write(ent_out_file, entities[part_begin + ix], embs[ix])
+                write(entities_output_file, entities[part_begin + ix], embs[ix])
                 if (ix + 1) % 5000 == 0:
                     print("- Processed %d entities so far..." % (ix + 1))
             print("- Processed %d entities in total" % len(embs))
 
             part_begin = part_begin + len(embs)
 
-    print("Done exporting entities data to %s" % getattr(ent_out_file, "name", "the output file"))
+    entities_output_filename = getattr(entities_output_file, "name", "the output file")
+    print("Done exporting entities data to %s" % entities_output_filename)
 
     # TODO Provide a better output format for relation parameters.
     print("Writing relation parameters...")
@@ -64,29 +65,30 @@ def make_tsv(
             for parameter in model.lhs_operators[0].parameters()
         ], dim=1)
         for rel_idx, rel_name in enumerate(relation_types):
-            write(rel_out_file, rel_name, lhs_parameters[rel_idx])
+            write(relation_types_output_file, rel_name, lhs_parameters[rel_idx])
 
         rhs_parameters = torch.cat([
             parameter.view(model.num_dynamic_rels, -1)
             for parameter in model.rhs_operators[0].parameters()
         ], dim=1)
         for rel_idx, rel_name in enumerate(relation_types):
-            write(rel_out_file, rel_name + "_reverse_relation", rhs_parameters[rel_idx])
+            write(relation_types_output_file, rel_name + "_reverse_relation", rhs_parameters[rel_idx])
     else:
         for rel_name, operator in zip(relation_types, model.rhs_operators):
-            write(rel_out_file, rel_name, torch.cat([
+            write(relation_types_output_file, rel_name, torch.cat([
                 parameter.flatten() for parameter in operator.parameters()
             ], dim=0))
 
-    print("Done exporting relations data to %s" % getattr(rel_out_file, "name", "the output file"))
+    relation_types_output_filename = getattr(relation_types_output_file, "name", "the output file"))
+    print("Done exporting relations data to %s" % relation_types_output_filename)
 
 
 def main():
     parser = argparse.ArgumentParser(description='Convert Data for PBG')
     parser.add_argument('--checkpoint')
     parser.add_argument('--dict', required=True)
-    parser.add_argument('--out-ent', required=True)
-    parser.add_argument('--out-rel', required=True)
+    parser.add_argument('--entities-output', required=True)
+    parser.add_argument('--relation-types-output', required=True)
 
     args = parser.parse_args()
 

--- a/torchbiggraph/converters/export_to_tsv.py
+++ b/torchbiggraph/converters/export_to_tsv.py
@@ -24,7 +24,8 @@ def make_tsv(
     checkpoint: str,
     relation_types: List[str],
     entities_by_type: Dict[str, List[str]],
-    output_file: IO[str],
+    ent_out_file: IO[str],
+    rel_out_file: IO[str],
 ) -> None:
     print("Loading model check point...")
     checkpoint_manager = CheckpointManager(checkpoint)
@@ -46,7 +47,7 @@ def make_tsv(
                 embs += model.global_embs[model.EMB_PREFIX + entity_name]
 
             for ix in range(len(embs)):
-                write(output_file, entities[part_begin + ix], embs[ix])
+                write(ent_out_file, entities[part_begin + ix], embs[ix])
                 if (ix + 1) % 5000 == 0:
                     print("- Processed %d entities so far..." % (ix + 1))
             print("- Processed %d entities in total" % len(embs))
@@ -61,28 +62,29 @@ def make_tsv(
             for parameter in model.lhs_operators[0].parameters()
         ], dim=1)
         for rel_idx, rel_name in enumerate(relation_types):
-            write(output_file, rel_name, lhs_parameters[rel_idx])
+            write(rel_out_file, rel_name, lhs_parameters[rel_idx])
 
         rhs_parameters = torch.cat([
             parameter.view(model.num_dynamic_rels, -1)
             for parameter in model.rhs_operators[0].parameters()
         ], dim=1)
         for rel_idx, rel_name in enumerate(relation_types):
-            write(output_file, rel_name + "_reverse_relation", rhs_parameters[rel_idx])
+            write(rel_out_file, rel_name + "_reverse_relation", rhs_parameters[rel_idx])
     else:
         for rel_name, operator in zip(relation_types, model.rhs_operators):
-            write(output_file, rel_name, torch.cat([
+            write(rel_out_file, rel_name, torch.cat([
                 parameter.flatten() for parameter in operator.parameters()
             ], dim=0))
 
-    print("Done exporting data to %s" % getattr(output_file, "name", "the output file"))
+    print("Done exporting data to %s" % getattr(ent_out_file, "name", "the output file"))
 
 
 def main():
     parser = argparse.ArgumentParser(description='Convert Data for PBG')
     parser.add_argument('--checkpoint')
     parser.add_argument('--dict', required=True)
-    parser.add_argument('--out', required=True)
+    parser.add_argument('--out-ent', required=True)
+    parser.add_argument('--out-rel', required=True)
 
     args = parser.parse_args()
 
@@ -90,8 +92,8 @@ def main():
     with open(args.dict, "rt") as tf:
         dump = json.load(tf)
 
-    with open(args.out, "wt") as out_tf:
-        make_tsv(args.checkpoint, dump["relations"], dump["entities"], out_tf)
+    with open(args.out_ent, "wt") as ent_out_tf, open(args.out_rel, "wt") as ent_out_tf:
+        make_tsv(args.checkpoint, dump["relations"], dump["entities"], ent_out_tf, ent_out_tf)
 
 
 if __name__ == "__main__":

--- a/torchbiggraph/converters/export_to_tsv.py
+++ b/torchbiggraph/converters/export_to_tsv.py
@@ -54,6 +54,8 @@ def make_tsv(
 
             part_begin = part_begin + len(embs)
 
+    print("Done exporting entities data to %s" % getattr(ent_out_file, "name", "the output file"))
+
     # TODO Provide a better output format for relation parameters.
     print("Writing relation parameters...")
     if model.num_dynamic_rels > 0:
@@ -76,7 +78,7 @@ def make_tsv(
                 parameter.flatten() for parameter in operator.parameters()
             ], dim=0))
 
-    print("Done exporting data to %s" % getattr(ent_out_file, "name", "the output file"))
+    print("Done exporting relations data to %s" % getattr(rel_out_file, "name", "the output file"))
 
 
 def main():

--- a/torchbiggraph/converters/export_to_tsv.py
+++ b/torchbiggraph/converters/export_to_tsv.py
@@ -79,7 +79,7 @@ def make_tsv(
                 parameter.flatten() for parameter in operator.parameters()
             ], dim=0))
 
-    relation_types_output_filename = getattr(relation_types_output_file, "name", "the output file"))
+    relation_types_output_filename = getattr(relation_types_output_file, "name", "the output file")
     print("Done exporting relations data to %s" % relation_types_output_filename)
 
 


### PR DESCRIPTION
## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

Having all the embeddings exported into a single file it's quite unhandy, since and is non-trivial to split the file later.

This PR introduces the changes needed to allow the use of separate output stream for entities and relations in `make_tsv`.

## Checklist

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
