### PR TITLE
Fix import_from_tsv in case of empty bucket

### DIFF
--- a/torchbiggraph/converters/import_from_tsv.py
+++ b/torchbiggraph/converters/import_from_tsv.py
@@ -236,7 +236,7 @@ def generate_edge_path_files(
         for j in range(num_rhs_parts):
             print("- Writing bucket (%d, %d), containing %d edges..."
                   % (i, j, len(buckets[i, j])))
-            edges = np.asarray(buckets[i, j])
+            edges = np.array(buckets[i, j], dtype=np.int64).reshape((-1, 3))
             with h5py.File(os.path.join(
                 edge_path_out, "edges_%d_%d.h5" % (i, j)
             ), "w") as hf:


### PR DESCRIPTION
## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

np.array([]) has shape (0,) and type float64, whereas we expected it to have shape (0, 3) and type int64.

Fixes #71.

## How Has This Been Tested (if it applies)

Ran `import_from_tsv` with an empty edgelist file before and after this change.