### PR TITLE
Fix Bug: torchbiggraph_example_fb15k trainning stop

### DIFF
--- a/torchbiggraph/train.py
+++ b/torchbiggraph/train.py
@@ -771,14 +771,15 @@ def train_and_report_stats(
                 bucket_logger.info(f"Stats after training: {eval_stats_after}")
 
             # Add train/eval metrics to queue
-            checkpoint_manager.append_stats(
-                {
-                    "index": current_index,
-                    "eval_stats_before": eval_stats_before.to_dict(),
-                    "stats": stats.to_dict(),
-                    "eval_stats_after": eval_stats_after.to_dict(),
-                }
-            )
+            if num_eval_edges > 0:
+                checkpoint_manager.append_stats(
+                    {
+                        "index": current_index,
+                        "eval_stats_before": eval_stats_before.to_dict(),
+                        "stats": stats.to_dict(),
+                        "eval_stats_after": eval_stats_after.to_dict(),
+                    }
+                )
             yield current_index, eval_stats_before, stats, eval_stats_after
 
         swap_partitioned_embeddings(cur_b, None)


### PR DESCRIPTION
torchbiggraph_example_fb15k trainning stop for eval_stats_before is none at first epoch.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue
$ torchbiggraph_example_fb15k
Downloading https://dl.fbaipublicfiles.com/starspace/fb15k.tgz to data/fb15k.tgz
7.67MB [00:04, 1.76MB/s]                                                                                                                               
Downloaded and extracted file.
Looking up relation types in the edge files...
- Found 1345 relation types
- Removing the ones with fewer than 1 occurrences...
- Left with 1345 relation types
- Shuffling them...
Searching for the entities in the edge files...
Entity type all:
- Found 14951 entities
- Removing the ones with fewer than 1 occurrences...
- Left with 14951 entities
- Shuffling them...
Preparing counts and dictionaries for entities and relation types:
- Writing count of entity type all and partition 0
- Writing count of dynamic relations
Preparing edge path data/FB15k/freebase_mtr100_mte100-train_partitioned, out of the edges found in data/FB15k/freebase_mtr100_mte100-train.txt
- Edges will be partitioned in 1 x 1 buckets.
- Processed 100000 edges so far...
- Processed 200000 edges so far...
- Processed 300000 edges so far...
- Processed 400000 edges so far...
- Processed 483142 edges in total
- Writing bucket (0, 0), containing 483142 edges...
2019-09-20 11:46:56,178  [ainProcess] Flushing one chunk of 131072 elements to dataset 'lhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
2019-09-20 11:46:56,180  [ainProcess] Flushing one chunk of 131072 elements to dataset 'lhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
2019-09-20 11:46:56,181  [ainProcess] Flushing one chunk of 131072 elements to dataset 'lhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
2019-09-20 11:46:56,182  [ainProcess] Flushing one chunk of 131072 elements to dataset 'rhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
2019-09-20 11:46:56,183  [ainProcess] Flushing one chunk of 131072 elements to dataset 'rhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
2019-09-20 11:46:56,184  [ainProcess] Flushing one chunk of 131072 elements to dataset 'rhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
2019-09-20 11:46:56,186  [ainProcess] Flushing one chunk of 131072 elements to dataset 'rel' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
2019-09-20 11:46:56,187  [ainProcess] Flushing one chunk of 131072 elements to dataset 'rel' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
2019-09-20 11:46:56,188  [ainProcess] Flushing one chunk of 131072 elements to dataset 'rel' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
2019-09-20 11:46:56,189  [ainProcess] Flushing one chunk of 89926 elements to dataset 'lhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
2019-09-20 11:46:56,190  [ainProcess] Flushing one chunk of 89926 elements to dataset 'rhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
2019-09-20 11:46:56,191  [ainProcess] Flushing one chunk of 89926 elements to dataset 'rel' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
Preparing edge path data/FB15k/freebase_mtr100_mte100-valid_partitioned, out of the edges found in data/FB15k/freebase_mtr100_mte100-valid.txt
- Edges will be partitioned in 1 x 1 buckets.
- Processed 50000 edges in total
- Writing bucket (0, 0), containing 50000 edges...
2019-09-20 11:46:56,457  [ainProcess] Flushing one chunk of 50000 elements to dataset 'lhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-valid_partitioned/edges_0_0.tmp.h5
2019-09-20 11:46:56,458  [ainProcess] Flushing one chunk of 50000 elements to dataset 'rhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-valid_partitioned/edges_0_0.tmp.h5
2019-09-20 11:46:56,458  [ainProcess] Flushing one chunk of 50000 elements to dataset 'rel' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-valid_partitioned/edges_0_0.tmp.h5
Preparing edge path data/FB15k/freebase_mtr100_mte100-test_partitioned, out of the edges found in data/FB15k/freebase_mtr100_mte100-test.txt
- Edges will be partitioned in 1 x 1 buckets.
- Processed 59071 edges in total
- Writing bucket (0, 0), containing 59071 edges...
2019-09-20 11:46:56,721  [ainProcess] Flushing one chunk of 59071 elements to dataset 'lhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-test_partitioned/edges_0_0.tmp.h5
2019-09-20 11:46:56,722  [ainProcess] Flushing one chunk of 59071 elements to dataset 'rhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-test_partitioned/edges_0_0.tmp.h5
2019-09-20 11:46:56,722  [ainProcess] Flushing one chunk of 59071 elements to dataset 'rel' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-test_partitioned/edges_0_0.tmp.h5
2019-09-20 11:46:56,727   [Trainer-0] Loading entity counts...
2019-09-20 11:46:56,727   [Trainer-0] Creating workers...
2019-09-20 11:46:56,768   [Trainer-0] Initializing global model...
2019-09-20 11:46:56,808   [Trainer-0] Starting epoch 1 / 50, edge path 1 / 1, edge chunk 1 / 1
2019-09-20 11:46:56,809   [Trainer-0] Edge path: data/FB15k/freebase_mtr100_mte100-train_partitioned
2019-09-20 11:46:56,809   [Trainer-0] still in queue: 0
2019-09-20 11:46:56,809   [Trainer-0] Swapping partitioned embeddings None ( 0 , 0 )
2019-09-20 11:46:56,809   [Trainer-0] ( 0 , 0 ): Loading entities
2019-09-20 11:48:02,435   [Trainer-0] ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 65.59 s ( 0.0074 M/sec ); io: 0.04 s ( 316.80 MB/sec )
2019-09-20 11:48:02,436   [Trainer-0] ( 0 , 0 ): loss:  1117.25 , violators_lhs:  95.9375 , violators_rhs:  91.8576 , count:  483142
Traceback (most recent call last):
  File "/home/dell/.local/bin/torchbiggraph_example_fb15k", line 11, in <module>
    load_entry_point('torchbiggraph==1.dev1', 'console_scripts', 'torchbiggraph_example_fb15k')()
  File "/home/dell/.local/lib/python3.6/site-packages/torchbiggraph/examples/fb15k.py", line 87, in main
    train(train_config, subprocess_init=subprocess_init)
  File "/home/dell/.local/lib/python3.6/site-packages/torchbiggraph/train.py", line 878, in train
    for _ in train_and_report_stats(config, model, trainer, evaluator, rank, subprocess_init):
  File "/home/dell/.local/lib/python3.6/site-packages/torchbiggraph/train.py", line 777, in train_and_report_stats
    "eval_stats_before": eval_stats_before.to_dict(),
**AttributeError: 'NoneType' object has no attribute 'to_dict'**

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->
$ torchbiggraph_example_fb15k
Downloading https://dl.fbaipublicfiles.com/starspace/fb15k.tgz to data/fb15k.tgz
7.67MB [00:06, 1.27MB/s]                                                                                                                               
Downloaded and extracted file.
Looking up relation types in the edge files...
- Found 1345 relation types
- Removing the ones with fewer than 1 occurrences...
- Left with 1345 relation types
- Shuffling them...
Searching for the entities in the edge files...
Entity type all:
- Found 14951 entities
- Removing the ones with fewer than 1 occurrences...
- Left with 14951 entities
- Shuffling them...
Preparing counts and dictionaries for entities and relation types:
- Writing count of entity type all and partition 0
- Writing count of dynamic relations
Preparing edge path data/FB15k/freebase_mtr100_mte100-train_partitioned, out of the edges found in data/FB15k/freebase_mtr100_mte100-train.txt
- Edges will be partitioned in 1 x 1 buckets.
- Processed 100000 edges so far...
- Processed 200000 edges so far...
- Processed 300000 edges so far...
- Processed 400000 edges so far...
- Processed 483142 edges in total
- Writing bucket (0, 0), containing 483142 edges...
2019-09-20 14:13:10,718  [ainProcess] Flushing one chunk of 131072 elements to dataset 'lhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
2019-09-20 14:13:10,720  [ainProcess] Flushing one chunk of 131072 elements to dataset 'lhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
2019-09-20 14:13:10,721  [ainProcess] Flushing one chunk of 131072 elements to dataset 'lhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
2019-09-20 14:13:10,723  [ainProcess] Flushing one chunk of 131072 elements to dataset 'rhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
2019-09-20 14:13:10,723  [ainProcess] Flushing one chunk of 131072 elements to dataset 'rhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
2019-09-20 14:13:10,725  [ainProcess] Flushing one chunk of 131072 elements to dataset 'rhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
2019-09-20 14:13:10,726  [ainProcess] Flushing one chunk of 131072 elements to dataset 'rel' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
2019-09-20 14:13:10,727  [ainProcess] Flushing one chunk of 131072 elements to dataset 'rel' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
2019-09-20 14:13:10,728  [ainProcess] Flushing one chunk of 131072 elements to dataset 'rel' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
2019-09-20 14:13:10,729  [ainProcess] Flushing one chunk of 89926 elements to dataset 'lhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
2019-09-20 14:13:10,730  [ainProcess] Flushing one chunk of 89926 elements to dataset 'rhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
2019-09-20 14:13:10,731  [ainProcess] Flushing one chunk of 89926 elements to dataset 'rel' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-train_partitioned/edges_0_0.tmp.h5
Preparing edge path data/FB15k/freebase_mtr100_mte100-valid_partitioned, out of the edges found in data/FB15k/freebase_mtr100_mte100-valid.txt
- Edges will be partitioned in 1 x 1 buckets.
- Processed 50000 edges in total
- Writing bucket (0, 0), containing 50000 edges...
2019-09-20 14:13:10,975  [ainProcess] Flushing one chunk of 50000 elements to dataset 'lhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-valid_partitioned/edges_0_0.tmp.h5
2019-09-20 14:13:10,976  [ainProcess] Flushing one chunk of 50000 elements to dataset 'rhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-valid_partitioned/edges_0_0.tmp.h5
2019-09-20 14:13:10,977  [ainProcess] Flushing one chunk of 50000 elements to dataset 'rel' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-valid_partitioned/edges_0_0.tmp.h5
Preparing edge path data/FB15k/freebase_mtr100_mte100-test_partitioned, out of the edges found in data/FB15k/freebase_mtr100_mte100-test.txt
- Edges will be partitioned in 1 x 1 buckets.
- Processed 59071 edges in total
- Writing bucket (0, 0), containing 59071 edges...
2019-09-20 14:13:11,245  [ainProcess] Flushing one chunk of 59071 elements to dataset 'lhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-test_partitioned/edges_0_0.tmp.h5
2019-09-20 14:13:11,245  [ainProcess] Flushing one chunk of 59071 elements to dataset 'rhs' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-test_partitioned/edges_0_0.tmp.h5
2019-09-20 14:13:11,246  [ainProcess] Flushing one chunk of 59071 elements to dataset 'rel' of file /media/dell/cb719d25-a874-4c40-9a6e-da0277fe228c/WorkSpace/BigGraph/data/FB15k/freebase_mtr100_mte100-test_partitioned/edges_0_0.tmp.h5
2019-09-20 14:13:11,251   [Trainer-0] Loading entity counts...
2019-09-20 14:13:11,251   [Trainer-0] Creating workers...
2019-09-20 14:13:11,312   [Trainer-0] Initializing global model...
2019-09-20 14:13:11,385   [Trainer-0] Starting epoch 1 / 50, edge path 1 / 1, edge chunk 1 / 1
2019-09-20 14:13:11,385   [Trainer-0] Edge path: data/FB15k/freebase_mtr100_mte100-train_partitioned
2019-09-20 14:13:11,385   [Trainer-0] still in queue: 0
2019-09-20 14:13:11,385   [Trainer-0] Swapping partitioned embeddings None ( 0 , 0 )
2019-09-20 14:13:11,385   [Trainer-0] ( 0 , 0 ): Loading entities
2019-09-20 14:14:17,329   [Trainer-0] ( 0 , 0 ): bucket 1 / 1 : Processed 483142 edges in 65.88 s ( 0.0073 M/sec ); io: 0.06 s ( 178.89 MB/sec )
2019-09-20 14:14:17,329   [Trainer-0] ( 0 , 0 ): loss:  7.45275 , violators_lhs:  97.7972 , violators_rhs:  93.5017 , count:  483142
2019-09-20 14:14:17,329   [Trainer-0] Swapping partitioned embeddings ( 0 , 0 ) None
2019-09-20 14:14:17,329   [Trainer-0] Writing partitioned embeddings
2019-09-20 14:14:17,329   [Trainer-0] Finished epoch 1 / 50, edge path 1 / 1, edge chunk 1 / 1
2019-09-20 14:14:17,343   [Trainer-0] Writing the metadata
2019-09-20 14:14:17,352   [Trainer-0] Writing the checkpoint
2019-09-20 14:14:17,352   [Trainer-0] Switching to the new checkpoint version
2019-09-20 14:14:17,446   [Trainer-0] Starting epoch 2 / 50, edge path 1 / 1, edge chunk 1 / 1
2019-09-20 14:14:17,446   [Trainer-0] Edge path: data/FB15k/freebase_mtr100_mte100-train_partitioned
2019-09-20 14:14:17,446   [Trainer-0] still in queue: 0
2019-09-20 14:14:17,446   [Trainer-0] Swapping partitioned embeddings None ( 0 , 0 )
2019-09-20 14:14:17,447   [Trainer-0] ( 0 , 0 ): Loading entities

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] The documentation is up-to-date with the changes I made.
- [ ] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ x] All tests passed, and additional code has been covered with new tests.
