### PR TITLE
Include docs and other text files in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,5 @@
 global-include LICENSE*
+include *.md
+graft docs
+prune docs/build
+global-exclude .*


### PR DESCRIPTION
Make the source distribution match the GitHub repo, except for "metadata" files related to our "infrastructure" (.gitignore, .github/, .circleci/).

Fixes #103, although it doesn't exactly fix the issue there because we've gotten rid of the requirements.txt file a while ago (including its contents in setup.cfg) and that issue has already disappeared.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

See #103.

## How Has This Been Tested (if it applies)

I ran `./setup.py sdist` and inspected the tar.gz.