### PR TITLE
Fix ZeroDivisionError

### DIFF
--- a/torchbiggraph/train.py
+++ b/torchbiggraph/train.py
@@ -784,11 +784,13 @@ def train_and_report_stats(
             stats = Stats.sum(all_stats).average()
             compute_time = time.time() - tic
 
+            edges_velocity_log = f"( {num_edges / compute_time / 1e6:.2g} M/sec ); " if compute_time > 0 else f""
+            io_time_velocity_log = f"io: {io_time:.2g} s ( {io_bytes / io_time / 1e6:.2g} MB/sec )" if io_time > 0 else f"io: {io_time:.2g} s"
             bucket_logger.info(
                 f"bucket {total_buckets - remaining} / {total_buckets} : "
                 f"Processed {num_edges} edges in {compute_time:.2f} s "
-                f"( {num_edges / compute_time / 1e6:.2g} M/sec ); "
-                f"io: {io_time:.2f} s ( {io_bytes / io_time / 1e6:.2f} MB/sec )")
+                + edges_velocity_log
+                + io_time_velocity_log)
             bucket_logger.info(f"{stats}")
 
             # HOGWILD eval after training


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
The train failed if compute time or io time is zero.
<!--- Please link to an existing issue here if one exists. -->
https://github.com/facebookresearch/PyTorch-BigGraph/issues/115
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

It was tested on my local machine with different values of the compute_time and io_time variables.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] The documentation is up-to-date with the changes I made.
- [ ] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
