### PR TITLE
Refactor CPP installation checks to allow all modules to be imported for unit tests

### DIFF
--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -26,7 +26,8 @@ from torchbiggraph.config import ConfigSchema, EntitySchema, RelationSchema
 from torchbiggraph.eval import do_eval
 from torchbiggraph.partitionserver import run_partition_server
 from torchbiggraph.stats import SerializedStats
-from torchbiggraph.train import GPU_INSTALLED, train
+from torchbiggraph.train import train
+from torchbiggraph.train_gpu import CPP_INSTALLED
 from torchbiggraph.util import (
     SubprocessInitializer,
     call_one_after_the_other,
@@ -491,15 +492,15 @@ class TestFunctional(TestCase):
         self.assertCheckpointWritten(train_config, version=1)
         do_eval(eval_config, subprocess_init=self.subprocess_init)
 
-    @unittest.skipIf(not torch.cuda.is_available() or not GPU_INSTALLED, "No GPU")
+    @unittest.skipIf(not torch.cuda.is_available() or not CPP_INSTALLED, "No GPU")
     def test_gpu(self):
         self._test_gpu()
 
-    @unittest.skipIf(not torch.cuda.is_available() or not GPU_INSTALLED, "No GPU")
+    @unittest.skipIf(not torch.cuda.is_available() or not CPP_INSTALLED, "No GPU")
     def test_gpu_half(self):
         self._test_gpu(do_half_precision=True)
 
-    @unittest.skipIf(not torch.cuda.is_available() or not GPU_INSTALLED, "No GPU")
+    @unittest.skipIf(not torch.cuda.is_available() or not CPP_INSTALLED, "No GPU")
     def test_gpu_1partition(self):
         self._test_gpu(num_partitions=1)
 

--- a/torchbiggraph/train.py
+++ b/torchbiggraph/train.py
@@ -14,20 +14,13 @@ from torchbiggraph.batching import AbstractBatchProcessor
 from torchbiggraph.config import ConfigFileLoader, ConfigSchema, add_to_sys_path
 from torchbiggraph.model import MultiRelationEmbedder
 from torchbiggraph.train_cpu import TrainingCoordinator
+from torchbiggraph.train_gpu import GPUTrainingCoordinator
 from torchbiggraph.types import SINGLE_TRAINER, Rank
 from torchbiggraph.util import (
     SubprocessInitializer,
     set_logging_verbosity,
     setup_logging,
 )
-
-
-try:
-    from torchbiggraph.train_gpu import GPUTrainingCoordinator
-
-    GPU_INSTALLED = True
-except ImportError:
-    GPU_INSTALLED = False
 
 
 logger = logging.getLogger("torchbiggraph")
@@ -42,12 +35,6 @@ def train(
     rank: Rank = SINGLE_TRAINER,
     subprocess_init: Optional[Callable[[], None]] = None,
 ) -> None:
-    if config.num_gpus > 0 and not GPU_INSTALLED:
-        raise RuntimeError(
-            "GPU support requires C++ installation: "
-            "install with C++ support by running "
-            "`PBG_INSTALL_CPP=1 pip install .`"
-        )
     CoordinatorT = (
         GPUTrainingCoordinator if config.num_gpus > 0 else TrainingCoordinator
     )

--- a/torchbiggraph/train_gpu.py
+++ b/torchbiggraph/train_gpu.py
@@ -16,7 +16,6 @@ from typing import Callable, Dict, List, NamedTuple, Optional, Set, Tuple
 
 import torch
 import torch.multiprocessing as mp
-from torchbiggraph import _C
 from torchbiggraph.batching import AbstractBatchProcessor, process_in_batches
 from torchbiggraph.config import ConfigFileLoader, ConfigSchema, add_to_sys_path
 from torchbiggraph.edgelist import EdgeList
@@ -59,6 +58,14 @@ from torchbiggraph.util import (
     split_almost_equally,
     tag_logs_with_process_name,
 )
+
+
+try:
+    from torchbiggraph import _C
+
+    CPP_INSTALLED = True
+except ImportError:
+    CPP_INSTALLED = False
 
 
 logger = logging.getLogger("torchbiggraph")
@@ -423,6 +430,12 @@ class GPUTrainingCoordinator(TrainingCoordinator):
         )
 
         assert config.num_gpus > 0
+        if not CPP_INSTALLED:
+            raise RuntimeError(
+                "GPU support requires C++ installation: "
+                "install with C++ support by running "
+                "`PBG_INSTALL_CPP=1 pip install .`"
+            )
 
         if config.half_precision:
             for entity in config.entities:


### PR DESCRIPTION
Summary: We have some checks so that Filament can run when the C++ code isn't installed, but unittest still tries to important `train_gpu.py` directly and fails. This moves the check *inside* `train_gpu`.

Reviewed By: lw

Differential Revision: D22073228

