### PR TITLE
Install PyTorch dependencies in CircleCI env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
             python3 -m venv ~/venv
             . ~/venv/bin/activate
             pip install pip --upgrade --upgrade-strategy eager
-            pip install numpy
+            pip install dataclasses numpy typing_extensions
             pip install torch --no-index --find-links https://download.pytorch.org/whl/cpu/torch_stable.html --no-deps --upgrade --upgrade-strategy eager --progress-bar off
             pip install . --upgrade --upgrade-strategy eager --progress-bar off
             pip freeze > ~/pip_freeze.txt


### PR DESCRIPTION
Summary:
CircleCI at master is failing because our setup.py import PyTorch which in turn, at some point, imports typing_extensions, which isn't part of the standard library in Python 3.6.

PyTorch does indeed mark it as a dependency but unfortunately it's not installed in our CircleCI jobs because we install PyTorch in a weird way, in order to get the CPU-only build. (There's an alternative way of getting the CPU-only build which however requires pinning the PyTorch version, which I think is also bad).

Hence in this commit I explicitly install the new dependencies that PyTorch acquired. See:
https://github.com/pytorch/pytorch/blob/8855c4e12f51ed83b27e61a9174852330e5e5469/setup.py#L343-L347

Differential Revision: D24952012

